### PR TITLE
Add spoofing for just Streamline

### DIFF
--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -510,6 +510,11 @@ TargetDeviceId=auto
 ; Default (auto) is NVIDIA GeForce RTX 4090
 SpoofedGPUName=auto
 
+; Enables GPU spoofing for Streamline even if Dxgi spoofing is disabled for the rest of the game
+; Usually allows for using fakenvapi without spoofing the whole game, and sometimes DLSS/DLSSG
+; true or false - Default (auto) is false on Nvidia, true on Intel/AMD
+StreamlineSpoofing=auto
+
 ; Enables Nvidia GPU spoofing for DXGI
 ; true or false - Default (auto) is true
 Dxgi=auto

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -2,6 +2,7 @@
 #include "Config.h"
 #include "Util.h"
 #include "nvapi/fakenvapi.h"
+#include <hooks/Streamline_Hooks.h>
 
 static inline int64_t GetTicks()
 {
@@ -402,6 +403,7 @@ bool Config::Reload(std::filesystem::path iniPath)
             VulkanExtensionSpoofing.set_from_config(readBool("Spoofing", "VulkanExtensionSpoofing"));
             VulkanVRAM.set_from_config(readInt("Spoofing", "VulkanVRAM"));
             SpoofedGPUName.set_from_config(readWString("Spoofing", "SpoofedGPUName"));
+            StreamlineSpoofing.set_from_config(readBool("Spoofing", "StreamlineSpoofing"));
             SpoofHAGS.set_from_config(readBool("Spoofing", "SpoofHAGS"));
             SpoofFeatureLevel.set_from_config(readBool("Spoofing", "D3DFeatureLevel"));
             SpoofedVendorId.set_from_config(readUInt("Spoofing", "SpoofedVendorId"));
@@ -947,6 +949,8 @@ bool Config::SaveIni()
         ini.SetValue("Spoofing", "DxgiVRAM", GetIntValue(Instance()->DxgiVRAM.value_for_config()).c_str());
         ini.SetValue("Spoofing", "SpoofedGPUName",
                      wstring_to_string(Instance()->SpoofedGPUName.value_for_config_or(L"auto")).c_str());
+        ini.SetValue("Spoofing", "StreamlineSpoofing",
+                     GetBoolValue(Instance()->StreamlineSpoofing.value_for_config()).c_str());
         ini.SetValue("Spoofing", "SpoofHAGS", GetBoolValue(Instance()->SpoofHAGS.value_for_config()).c_str());
         ini.SetValue("Spoofing", "D3DFeatureLevel",
                      GetBoolValue(Instance()->SpoofFeatureLevel.value_for_config()).c_str());
@@ -1038,6 +1042,8 @@ bool Config::SaveFakenvapiIni()
     fakenvapiIni.SetLongValue("fakenvapi", "force_latencyflex", FN_ForceLatencyFlex.value_or(false));
     fakenvapiIni.SetLongValue("fakenvapi", "latencyflex_mode", FN_LatencyFlexMode.value_or(0));
     fakenvapiIni.SetLongValue("fakenvapi", "force_reflex", FN_ForceReflex.value_or(0));
+
+    StreamlineHooks::updateForceReflex();
 
     return fakenvapiIni.SaveFile(FN_iniPath.wstring().c_str()) >= 0;
 }

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -322,6 +322,7 @@ class Config
 
     // Spoofing
     CustomOptional<bool> DxgiSpoofing { true };
+    CustomOptional<bool> StreamlineSpoofing { true };
     CustomOptional<std::string, NoDefault> DxgiBlacklist; // disabled by default
     CustomOptional<int, NoDefault> DxgiVRAM;              // disabled by default
     CustomOptional<bool> VulkanSpoofing { false };

--- a/OptiScaler/DllNames.h
+++ b/OptiScaler/DllNames.h
@@ -118,6 +118,8 @@ DEFINE_NAME_VECTORS(nvapi, "nvapi64");
 DEFINE_NAME_VECTORS(slInterposer, "sl.interposer");
 DEFINE_NAME_VECTORS(slDlss, "sl.dlss");
 DEFINE_NAME_VECTORS(slDlssg, "sl.dlss_g");
+DEFINE_NAME_VECTORS(slReflex, "sl.reflex");
+DEFINE_NAME_VECTORS(slCommon, "sl.common");
 
 DEFINE_NAME_VECTORS(xess, "libxess");
 DEFINE_NAME_VECTORS(xessDx11, "libxess_dx11");

--- a/OptiScaler/Logger.cpp
+++ b/OptiScaler/Logger.cpp
@@ -104,6 +104,7 @@ void PrepareLogger()
                 file_sink->set_pattern("%H:%M:%S.%f\t%L\t%v");
 #else
                 file_sink->set_pattern("[%H:%M:%S.%f] [%L] %v");
+                // file_sink->set_pattern("[%H:%M:%S.%f] [thread %t] [%L] %v");
 #endif // LOG_ASYNC
 
                 sinks.push_back(file_sink);

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -318,6 +318,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="include\imgui\imgui_impl_uwp.h" />
     <ClInclude Include="include\imgui\imgui_impl_vulkan.h" />
     <ClInclude Include="include\imgui\imgui_impl_win32.h" />
+    <ClInclude Include="include\sl.param\parameters.h" />
     <ClInclude Include="inputs\FfxApiExe_Dx12.h" />
     <ClInclude Include="inputs\FfxApi_Vk.h" />
     <ClInclude Include="inputs\NVNGX_DLSS.h" />
@@ -464,6 +465,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClCompile Include="include\imgui\imgui_impl_uwp.cpp" />
     <ClCompile Include="include\imgui\imgui_impl_vulkan.cpp" />
     <ClCompile Include="include\imgui\imgui_impl_win32.cpp" />
+    <ClCompile Include="include\sl.param\parameters.cpp" />
     <ClCompile Include="inputs\FfxApiExe_Dx12.cpp" />
     <ClCompile Include="inputs\FfxApi_Vk.cpp" />
     <ClCompile Include="inputs\XeSS_Base.cpp" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -506,6 +506,9 @@
     <ClInclude Include="proxies\IGDExt_Proxy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\sl.param\parameters.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Config.cpp">
@@ -792,6 +795,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="hooks\Streamline_Hooks.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="include\sl.param\parameters.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -98,6 +98,8 @@ class State
     std::string NGX_OTA_Dlss;
     std::string NGX_OTA_Dlssd;
 
+    feature_version streamlineVersion = { 0, 0, 0 };
+
     API api = API::NotSelected;
     API swapchainApi = API::NotSelected;
 

--- a/OptiScaler/hooks/Crypt32_Hooks.h
+++ b/OptiScaler/hooks/Crypt32_Hooks.h
@@ -38,7 +38,9 @@ static BOOL hkCryptQueryObject(DWORD dwObjectType, const void* pvObject, DWORD d
         }
 
         if (pathString.contains("nvngx.dll") && !State::Instance().nvngxExists &&
-            State::Instance().nvngxReplacement.has_value() && Config::Instance()->DxgiSpoofing.value_or_default())
+            State::Instance().nvngxReplacement.has_value() &&
+            (Config::Instance()->DxgiSpoofing.value_or_default() ||
+             Config::Instance()->StreamlineSpoofing.value_or_default()))
         {
             LOG_DEBUG("Replacing nvngx with a signed dll");
             return o_CryptQueryObject(dwObjectType, State::Instance().nvngxReplacement.value().c_str(),

--- a/OptiScaler/hooks/Kernel_Hooks.h
+++ b/OptiScaler/hooks/Kernel_Hooks.h
@@ -141,8 +141,7 @@ class KernelHooks
         }
 
         // sl.interposer.dll
-        if (Config::Instance()->FGType.value_or_default() == FGType::Nukems &&
-            CheckDllName(&lcaseLibName, &slInterposerNames))
+        if (CheckDllName(&lcaseLibName, &slInterposerNames))
         {
             auto streamlineModule = KernelBaseProxy::LoadLibraryExA_()(lpLibFullPath, NULL, 0);
 
@@ -190,6 +189,40 @@ class KernelHooks
             }
 
             return dlssgModule;
+        }
+
+        // sl.reflex.dll
+        if (CheckDllName(&lcaseLibName, &slReflexNames))
+        {
+            auto reflexModule = KernelBaseProxy::LoadLibraryExA_()(lpLibFullPath, NULL, 0);
+
+            if (reflexModule != nullptr)
+            {
+                StreamlineHooks::hookReflex(reflexModule);
+            }
+            else
+            {
+                LOG_ERROR("Trying to load dll: {}", lcaseLibName);
+            }
+
+            return reflexModule;
+        }
+
+        // sl.common.dll
+        if (CheckDllName(&lcaseLibName, &slCommonNames))
+        {
+            auto commonModule = KernelBaseProxy::LoadLibraryExA_()(lpLibFullPath, NULL, 0);
+
+            if (commonModule != nullptr)
+            {
+                StreamlineHooks::hookCommon(commonModule);
+            }
+            else
+            {
+                LOG_ERROR("Trying to load dll: {}", lcaseLibName);
+            }
+
+            return commonModule;
         }
 
         // nvngx_dlss
@@ -561,8 +594,7 @@ class KernelHooks
         }
 
         // sl.interposer.dll
-        if (Config::Instance()->FGType.value_or_default() == FGType::Nukems &&
-            CheckDllNameW(&lcaseLibName, &slInterposerNamesW))
+        if (CheckDllNameW(&lcaseLibName, &slInterposerNamesW))
         {
             auto streamlineModule = KernelBaseProxy::LoadLibraryExW_()(lpLibFullPath, NULL, 0);
 
@@ -610,6 +642,40 @@ class KernelHooks
             }
 
             return dlssgModule;
+        }
+
+        // sl.reflex.dll
+        if (CheckDllNameW(&lcaseLibName, &slReflexNamesW))
+        {
+            auto reflexModule = KernelBaseProxy::LoadLibraryExW_()(lpLibFullPath, NULL, 0);
+
+            if (reflexModule != nullptr)
+            {
+                StreamlineHooks::hookReflex(reflexModule);
+            }
+            else
+            {
+                LOG_ERROR("Trying to load dll: {}", lcaseLibNameA);
+            }
+
+            return reflexModule;
+        }
+
+        // sl.common.dll
+        if (CheckDllNameW(&lcaseLibName, &slCommonNamesW))
+        {
+            auto commonModule = KernelBaseProxy::LoadLibraryExW_()(lpLibFullPath, NULL, 0);
+
+            if (commonModule != nullptr)
+            {
+                StreamlineHooks::hookCommon(commonModule);
+            }
+            else
+            {
+                LOG_ERROR("Trying to load dll: {}", lcaseLibNameA);
+            }
+
+            return commonModule;
         }
 
         if (Config::Instance()->DisableOverlays.value_or_default() && CheckDllNameW(&lcaseLibName, &blockOverlayNamesW))
@@ -1683,7 +1749,8 @@ class KernelHooks
     static DWORD hk_K32_GetFileAttributesW(LPCWSTR lpFileName)
     {
         if (!State::Instance().nvngxExists && State::Instance().nvngxReplacement.has_value() &&
-            Config::Instance()->DxgiSpoofing.value_or_default())
+            (Config::Instance()->DxgiSpoofing.value_or_default() ||
+             Config::Instance()->StreamlineSpoofing.value_or_default()))
         {
             auto path = wstring_to_string(std::wstring(lpFileName));
             to_lower_in_place(path);
@@ -1704,7 +1771,8 @@ class KernelHooks
                                      DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
     {
         if (!State::Instance().nvngxExists && State::Instance().nvngxReplacement.has_value() &&
-            Config::Instance()->DxgiSpoofing.value_or_default())
+            (Config::Instance()->DxgiSpoofing.value_or_default() ||
+             Config::Instance()->StreamlineSpoofing.value_or_default()))
         {
             auto path = wstring_to_string(std::wstring(lpFileName));
             to_lower_in_place(path);

--- a/OptiScaler/hooks/Streamline_Hooks.cpp
+++ b/OptiScaler/hooks/Streamline_Hooks.cpp
@@ -8,6 +8,9 @@
 #include <proxies/KernelBase_Proxy.h>
 #include <menu/menu_overlay_base.h>
 #include <nvapi/ReflexHooks.h>
+#include <magic_enum.hpp>
+#include <sl1_reflex.h>
+#include "include/sl.param/parameters.h"
 
 // interposer
 decltype(&slInit) StreamlineHooks::o_slInit = nullptr;
@@ -17,11 +20,27 @@ decltype(&sl1::slInit) StreamlineHooks::o_slInit_sl1 = nullptr;
 sl::PFun_LogMessageCallback* StreamlineHooks::o_logCallback = nullptr;
 sl1::pfunLogMessageCallback* StreamlineHooks::o_logCallback_sl1 = nullptr;
 
+// DLSS
 StreamlineHooks::PFN_slGetPluginFunction StreamlineHooks::o_dlss_slGetPluginFunction = nullptr;
 StreamlineHooks::PFN_slOnPluginLoad StreamlineHooks::o_dlss_slOnPluginLoad = nullptr;
+
+// DLSSG
 StreamlineHooks::PFN_slGetPluginFunction StreamlineHooks::o_dlssg_slGetPluginFunction = nullptr;
 StreamlineHooks::PFN_slOnPluginLoad StreamlineHooks::o_dlssg_slOnPluginLoad = nullptr;
 decltype(&slDLSSGSetOptions) StreamlineHooks::o_slDLSSGSetOptions = nullptr;
+
+// Reflex
+StreamlineHooks::PFN_slGetPluginFunction StreamlineHooks::o_reflex_slGetPluginFunction = nullptr;
+StreamlineHooks::PFN_slSetConstants_sl1 StreamlineHooks::o_reflex_slSetConstants_sl1 = nullptr;
+StreamlineHooks::PFN_slOnPluginLoad StreamlineHooks::o_reflex_slOnPluginLoad = nullptr;
+decltype(&slReflexSetOptions) StreamlineHooks::o_slReflexSetOptions = nullptr;
+sl::ReflexMode StreamlineHooks::reflexGamesLastMode = sl::ReflexMode::eOff;
+
+// Common
+StreamlineHooks::PFN_slGetPluginFunction StreamlineHooks::o_common_slGetPluginFunction = nullptr;
+StreamlineHooks::PFN_slOnPluginLoad StreamlineHooks::o_common_slOnPluginLoad = nullptr;
+StreamlineHooks::PFN_slSetParameters_sl1 StreamlineHooks::o_common_slSetParameters_sl1 = nullptr;
+StreamlineHooks::PFN_setVoid StreamlineHooks::o_setVoid = nullptr;
 
 char* StreamlineHooks::trimStreamlineLog(const char* msg)
 {
@@ -131,12 +150,65 @@ bool StreamlineHooks::hkslInit_sl1(sl1::Preferences* pref, int applicationId)
     return o_slInit_sl1(*pref, applicationId);
 }
 
-bool StreamlineHooks::hkslOnPluginLoad(PFN_slOnPluginLoad o_slOnPluginLoad, std::string& config, void* params,
-                                       const char* loaderJSON, const char** pluginJSON)
+enum class VendorId : uint32_t
+{
+    eMS = 0x1414, // Software Render Adapter
+    eNVDA = 0x10DE,
+    eAMD = 0x1002,
+    eIntel = 0x8086,
+};
+
+struct Adapter
+{
+    LUID id {};
+    VendorId vendor {};
+    uint32_t bit; // in the adapter bit-mask
+    uint32_t architecture {};
+    uint32_t implementation {};
+    uint32_t revision {};
+    uint32_t deviceId {};
+    void* nativeInterface {};
+};
+
+constexpr uint32_t kMaxNumSupportedGPUs = 8;
+
+struct SystemCaps
+{
+    uint32_t gpuCount {};
+    uint32_t osVersionMajor {};
+    uint32_t osVersionMinor {};
+    uint32_t osVersionBuild {};
+    uint32_t driverVersionMajor {};
+    uint32_t driverVersionMinor {};
+    Adapter adapters[kMaxNumSupportedGPUs] {};
+    uint32_t gpuLoad[kMaxNumSupportedGPUs] {}; // percentage
+    bool hwsSupported {};                      // OS wide setting, not per adapter
+    bool laptopDevice {};
+};
+
+struct SystemCapsSl15
+{
+    uint32_t gpuCount {};
+    uint32_t osVersionMajor {};
+    uint32_t osVersionMinor {};
+    uint32_t osVersionBuild {};
+    uint32_t driverVersionMajor {};
+    uint32_t driverVersionMinor {};
+    uint32_t architecture[kMaxNumSupportedGPUs] {};
+    uint32_t implementation[kMaxNumSupportedGPUs] {};
+    uint32_t revision[kMaxNumSupportedGPUs] {};
+    uint32_t gpuLoad[kMaxNumSupportedGPUs] {}; // percentage
+    bool hwSchedulingEnabled {};
+};
+
+bool StreamlineHooks::hkdlss_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON)
 {
     LOG_FUNC();
 
-    auto result = o_slOnPluginLoad(params, loaderJSON, pluginJSON);
+    // TODO: do it better than "static" and hoping for the best
+    static std::string config;
+
+    auto result = o_dlss_slOnPluginLoad(params, loaderJSON, pluginJSON);
 
     if (Config::Instance()->VulkanExtensionSpoofing.value_or_default())
     {
@@ -154,18 +226,80 @@ bool StreamlineHooks::hkslOnPluginLoad(PFN_slOnPluginLoad o_slOnPluginLoad, std:
     return result;
 }
 
-bool StreamlineHooks::hkdlss_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON)
-{
-    // TODO: do it better than "static" and hoping for the best
-    static std::string config;
-    return hkslOnPluginLoad(o_dlss_slOnPluginLoad, config, params, loaderJSON, pluginJSON);
-}
-
 bool StreamlineHooks::hkdlssg_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON)
 {
+    LOG_FUNC();
+
     // TODO: do it better than "static" and hoping for the best
     static std::string config;
-    return hkslOnPluginLoad(o_dlssg_slOnPluginLoad, config, params, loaderJSON, pluginJSON);
+
+    auto result = o_dlssg_slOnPluginLoad(params, loaderJSON, pluginJSON);
+    nlohmann::json configJson = nlohmann::json::parse(*pluginJSON);
+
+    if (Config::Instance()->VulkanExtensionSpoofing.value_or_default())
+    {
+        configJson["external"]["vk"]["instance"]["extensions"].clear();
+        configJson["external"]["vk"]["device"]["extensions"].clear();
+        configJson["external"]["vk"]["device"]["1.2_features"].clear();
+    }
+
+    config = configJson.dump();
+
+    *pluginJSON = config.c_str();
+
+    return result;
+}
+
+bool StreamlineHooks::hkcommon_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON)
+{
+    LOG_FUNC();
+    auto result = o_common_slOnPluginLoad(params, loaderJSON, pluginJSON);
+
+    if (Config::Instance()->StreamlineSpoofing.value_or_default())
+    {
+        if (State::Instance().streamlineVersion.major > 1)
+        {
+            SystemCaps* caps = {};
+            sl::param::getPointerParam((sl::param::IParameters*) params, sl::param::common::kSystemCaps, &caps);
+
+            if (caps)
+            {
+                for (auto& adapter : caps->adapters)
+                {
+                    if ((uint32_t) adapter.vendor != 0)
+                    {
+                        adapter.vendor = VendorId::eNVDA;
+                        adapter.architecture = UINT_MAX;
+                    }
+                }
+
+                caps->driverVersionMajor = 999;
+                caps->hwsSupported = true;
+            }
+        }
+        else if (State::Instance().streamlineVersion.major == 1)
+        {
+            // This should be Streamline 1.5 as previous versions don't even have slOnPluginLoad
+
+            LOG_TRACE(
+                "Attempting to change system caps for Streamline v1, this could fail depending on the exact version");
+            SystemCapsSl15* caps = {};
+            sl::param::getPointerParam((sl::param::IParameters*) params, sl::param::common::kSystemCaps, &caps);
+
+            if (caps)
+            {
+                caps->architecture[0] = UINT_MAX;
+                caps->driverVersionMajor = 999;
+
+                // This will write outside the struct if SystemCaps is smaller than expected
+                // Witcher 3 (sl 1.5) uses this layout
+                // Layout from Streamline 1.3 is somehow bigger than this so it should be fine
+                caps->hwSchedulingEnabled = true;
+            }
+        }
+    }
+
+    return result;
 }
 
 sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewport, const sl::DLSSGOptions& options)
@@ -193,9 +327,30 @@ sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewpo
     return o_slDLSSGSetOptions(viewport, options);
 }
 
+bool StreamlineHooks::hkreflex_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON)
+{
+    auto result = o_reflex_slOnPluginLoad(params, loaderJSON, pluginJSON);
+    return result;
+}
+
+sl::Result StreamlineHooks::hkslReflexSetOptions(const sl::ReflexOptions& options)
+{
+    reflexGamesLastMode = options.mode;
+
+    sl::ReflexOptions newOptions = options;
+
+    if (Config::Instance()->FN_ForceReflex == 2)
+        newOptions.mode = sl::ReflexMode::eLowLatencyWithBoost;
+
+    if (Config::Instance()->FN_ForceReflex == 1)
+        newOptions.mode = sl::ReflexMode::eOff;
+
+    return o_slReflexSetOptions(newOptions);
+}
+
 void* StreamlineHooks::hkdlss_slGetPluginFunction(const char* functionName)
 {
-    LOG_DEBUG("{}", functionName);
+    // LOG_DEBUG("{}", functionName);
 
     if (strcmp(functionName, "slOnPluginLoad") == 0)
     {
@@ -208,7 +363,7 @@ void* StreamlineHooks::hkdlss_slGetPluginFunction(const char* functionName)
 
 void* StreamlineHooks::hkdlssg_slGetPluginFunction(const char* functionName)
 {
-    LOG_DEBUG("{}", functionName);
+    // LOG_DEBUG("{}", functionName);
 
     if (strcmp(functionName, "slOnPluginLoad") == 0)
     {
@@ -223,6 +378,138 @@ void* StreamlineHooks::hkdlssg_slGetPluginFunction(const char* functionName)
     }
 
     return o_dlssg_slGetPluginFunction(functionName);
+}
+
+bool StreamlineHooks::hkreflex_slSetConstants_sl1(const void* data, uint32_t frameIndex, uint32_t id)
+{
+    // Streamline v1's version of slReflexSetOptions + slPCLSetMarker
+    static sl1::ReflexConstants constants {};
+    constants = *(const sl1::ReflexConstants*) data;
+
+    reflexGamesLastMode = (sl::ReflexMode) constants.mode;
+
+    LOG_DEBUG("mode: {}, frameIndex: {}, id: {}", (uint32_t) constants.mode, frameIndex, id);
+
+    if (Config::Instance()->FN_ForceReflex == 2)
+        constants.mode = sl1::ReflexMode::eReflexModeLowLatencyWithBoost;
+    else if (Config::Instance()->FN_ForceReflex == 1)
+        constants.mode = sl1::ReflexMode::eReflexModeOff;
+
+    return o_reflex_slSetConstants_sl1(&constants, frameIndex, id);
+}
+
+void* StreamlineHooks::hkreflex_slGetPluginFunction(const char* functionName)
+{
+    // LOG_DEBUG("{}", functionName);
+
+    if (strcmp(functionName, "slSetConstants") == 0 && State::Instance().streamlineVersion.major == 1)
+    {
+        o_reflex_slSetConstants_sl1 = (PFN_slSetConstants_sl1) o_reflex_slGetPluginFunction(functionName);
+        return &hkreflex_slSetConstants_sl1;
+    }
+
+    if (strcmp(functionName, "slOnPluginLoad") == 0)
+    {
+        o_reflex_slOnPluginLoad = (PFN_slOnPluginLoad) o_reflex_slGetPluginFunction(functionName);
+        return &hkreflex_slOnPluginLoad;
+    }
+
+    if (strcmp(functionName, "slReflexSetOptions") == 0)
+    {
+        o_slReflexSetOptions = (decltype(&slReflexSetOptions)) o_reflex_slGetPluginFunction(functionName);
+        return &hkslReflexSetOptions;
+    }
+
+    return o_reflex_slGetPluginFunction(functionName);
+}
+
+bool StreamlineHooks::hk_setVoid(void* self, const char* key, void** value)
+{
+    // LOG_DEBUG("{}", key);
+
+    if (strcmp(key, sl::param::common::kSystemCaps) == 0)
+    {
+        LOG_TRACE("Attempting to change system caps for Streamline v1, this could fail depending on the exact version");
+
+        // SystemCapsSl15 is not entirely correct for Streamline 1.3
+        // But we here only use the beginning that matches + extra
+        auto caps = (SystemCapsSl15*) value;
+
+        if (caps)
+        {
+            caps->gpuCount = 1;
+            caps->architecture[0] = UINT_MAX;
+            caps->driverVersionMajor = 999;
+
+            // HAGS
+            *((char*) value + 56) = (char) 0x01;
+        }
+    }
+
+    return o_setVoid(self, key, value);
+}
+
+void StreamlineHooks::hkcommon_slSetParameters_sl1(void* params)
+{
+    LOG_FUNC();
+
+    if (o_setVoid == nullptr && params)
+    {
+        void** vtable = *(void***) params;
+
+        // It's flipped, 0 -> set void*, 7 -> get void*
+        o_setVoid = (PFN_setVoid) vtable[0];
+
+        DetourTransactionBegin();
+        DetourUpdateThread(GetCurrentThread());
+
+        if (o_setVoid != nullptr)
+            DetourAttach(&(PVOID&) o_setVoid, hk_setVoid);
+
+        DetourTransactionCommit();
+    }
+
+    o_common_slSetParameters_sl1(params);
+}
+
+void* StreamlineHooks::hkcommon_slGetPluginFunction(const char* functionName)
+{
+    // LOG_DEBUG("{}", functionName);
+
+    if (strcmp(functionName, "slOnPluginLoad") == 0)
+    {
+        o_common_slOnPluginLoad = (PFN_slOnPluginLoad) o_common_slGetPluginFunction(functionName);
+        return &hkcommon_slOnPluginLoad;
+    }
+
+    // Used around Streamline v1.3, as 1.5 doesn't seem to have it anymore
+    if (strcmp(functionName, "slSetParameters") == 0)
+    {
+        o_common_slSetParameters_sl1 = (PFN_slSetParameters_sl1) o_common_slGetPluginFunction(functionName);
+        return &hkcommon_slSetParameters_sl1;
+    }
+
+    return o_common_slGetPluginFunction(functionName);
+}
+
+void StreamlineHooks::updateForceReflex()
+{
+    // Not needed for Streamline v1 as slSetConstants is sent every frame
+    if (o_slReflexSetOptions)
+    {
+        sl::ReflexOptions options;
+
+        auto forceReflex = Config::Instance()->FN_ForceReflex.value_or_default();
+
+        if (forceReflex == 2)
+            options.mode = sl::ReflexMode::eLowLatencyWithBoost;
+        else if (forceReflex == 1)
+            options.mode = sl::ReflexMode::eOff;
+        else if (forceReflex == 0)
+            options.mode = reflexGamesLastMode;
+
+        auto result = o_slReflexSetOptions(options);
+    }
 }
 
 // SL INTERPOSER
@@ -269,6 +556,13 @@ void StreamlineHooks::hookInterposer(HMODULE slInterposer)
         return;
     }
 
+    static HMODULE last_slInterposer = nullptr;
+
+    if (last_slInterposer == slInterposer)
+        return;
+
+    last_slInterposer = slInterposer;
+
     // Looks like when reading DLL version load methods are called
     // To prevent loops disabling checks for sl.interposer.dll
     State::DisableChecks(7, "sl.interposer");
@@ -282,6 +576,11 @@ void StreamlineHooks::hookInterposer(HMODULE slInterposer)
 
         Util::version_t sl_version;
         Util::GetDLLVersion(string_to_wstring(dllPath), &sl_version);
+
+        State::Instance().streamlineVersion.major = sl_version.major;
+        State::Instance().streamlineVersion.minor = sl_version.minor;
+        State::Instance().streamlineVersion.patch = sl_version.patch;
+
         LOG_INFO("Streamline version: {}.{}.{}", sl_version.major, sl_version.minor, sl_version.patch);
 
         if (sl_version.major >= 2)
@@ -412,6 +711,98 @@ void StreamlineHooks::hookDlssg(HMODULE slDlssg)
         DetourUpdateThread(GetCurrentThread());
 
         DetourAttach(&(PVOID&) o_dlssg_slGetPluginFunction, hkdlssg_slGetPluginFunction);
+
+        DetourTransactionCommit();
+    }
+}
+
+// SL REFLEX
+
+void StreamlineHooks::unhookReflex()
+{
+    LOG_FUNC();
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+
+    if (o_reflex_slGetPluginFunction)
+    {
+        DetourDetach(&(PVOID&) o_reflex_slGetPluginFunction, hkreflex_slGetPluginFunction);
+        o_reflex_slGetPluginFunction = nullptr;
+    }
+
+    DetourTransactionCommit();
+}
+
+void StreamlineHooks::hookReflex(HMODULE slReflex)
+{
+    LOG_FUNC();
+
+    if (!slReflex)
+    {
+        LOG_WARN("Reflex module in NULL");
+        return;
+    }
+
+    if (o_reflex_slGetPluginFunction)
+        unhookReflex();
+
+    o_reflex_slGetPluginFunction =
+        reinterpret_cast<PFN_slGetPluginFunction>(KernelBaseProxy::GetProcAddress_()(slReflex, "slGetPluginFunction"));
+
+    if (o_reflex_slGetPluginFunction != nullptr)
+    {
+        LOG_TRACE("Hooking slGetPluginFunction in sl.reflex");
+        DetourTransactionBegin();
+        DetourUpdateThread(GetCurrentThread());
+
+        DetourAttach(&(PVOID&) o_reflex_slGetPluginFunction, hkreflex_slGetPluginFunction);
+
+        DetourTransactionCommit();
+    }
+}
+
+// SL COMMON
+
+void StreamlineHooks::unhookCommon()
+{
+    LOG_FUNC();
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+
+    if (o_common_slGetPluginFunction)
+    {
+        DetourDetach(&(PVOID&) o_common_slGetPluginFunction, hkcommon_slGetPluginFunction);
+        o_common_slGetPluginFunction = nullptr;
+    }
+
+    DetourTransactionCommit();
+}
+
+void StreamlineHooks::hookCommon(HMODULE slCommon)
+{
+    LOG_FUNC();
+
+    if (!slCommon)
+    {
+        LOG_WARN("Common module in NULL");
+        return;
+    }
+
+    if (o_common_slGetPluginFunction)
+        unhookCommon();
+
+    o_common_slGetPluginFunction =
+        reinterpret_cast<PFN_slGetPluginFunction>(KernelBaseProxy::GetProcAddress_()(slCommon, "slGetPluginFunction"));
+
+    if (o_common_slGetPluginFunction != nullptr)
+    {
+        LOG_TRACE("Hooking slGetPluginFunction in sl.common");
+        DetourTransactionBegin();
+        DetourUpdateThread(GetCurrentThread());
+
+        DetourAttach(&(PVOID&) o_common_slGetPluginFunction, hkcommon_slGetPluginFunction);
 
         DetourTransactionCommit();
     }

--- a/OptiScaler/hooks/Streamline_Hooks.h
+++ b/OptiScaler/hooks/Streamline_Hooks.h
@@ -6,12 +6,20 @@
 #include <sl.h>
 #include <sl1.h>
 #include <sl_dlss_g.h>
+#include <sl_pcl.h>
+#include <sl_reflex.h>
 
 class StreamlineHooks
 {
   public:
     typedef void* (*PFN_slGetPluginFunction)(const char* functionName);
     typedef bool (*PFN_slOnPluginLoad)(void* params, const char* loaderJSON, const char** pluginJSON);
+    typedef sl::Result (*PFN_slSetData)(const sl::BaseStructure* inputs, sl::CommandBuffer* cmdBuffer);
+    typedef bool (*PFN_slSetConstants_sl1)(const void* data, uint32_t frameIndex, uint32_t id);
+    typedef void (*PFN_slSetParameters_sl1)(void* params);
+    typedef bool (*PFN_setVoid)(void* self, const char* key, void** value);
+
+    static void updateForceReflex();
 
     static void unhookInterposer();
     static void hookInterposer(HMODULE slInterposer);
@@ -22,8 +30,14 @@ class StreamlineHooks
     static void unhookDlssg();
     static void hookDlssg(HMODULE slDlssg);
 
+    static void unhookReflex();
+    static void hookReflex(HMODULE slReflex);
+
+    static void unhookCommon();
+    static void hookCommon(HMODULE slCommon);
+
   private:
-    // interposer
+    // Interposer
     static decltype(&slInit) o_slInit;
     static decltype(&slSetTag) o_slSetTag;
     static decltype(&sl1::slInit) o_slInit_sl1;
@@ -31,25 +45,52 @@ class StreamlineHooks
     static sl::PFun_LogMessageCallback* o_logCallback;
     static sl1::pfunLogMessageCallback* o_logCallback_sl1;
 
-    // dlss / dlssg
+    static sl::Result hkslInit(sl::Preferences* pref, uint64_t sdkVersion);
+    static bool hkslInit_sl1(sl1::Preferences* pref, int applicationId);
+    static sl::Result hkslSetTag(sl::ViewportHandle& viewport, sl::ResourceTag* tags, uint32_t numTags,
+                                 sl::CommandBuffer* cmdBuffer);
+
+    // DLSS
     static PFN_slGetPluginFunction o_dlss_slGetPluginFunction;
     static PFN_slOnPluginLoad o_dlss_slOnPluginLoad;
+
+    static bool hkdlss_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON);
+    static void* hkdlss_slGetPluginFunction(const char* functionName);
+
+    // DLSSG
     static PFN_slGetPluginFunction o_dlssg_slGetPluginFunction;
     static PFN_slOnPluginLoad o_dlssg_slOnPluginLoad;
     static decltype(&slDLSSGSetOptions) o_slDLSSGSetOptions;
 
-    static char* trimStreamlineLog(const char* msg);
-    static void streamlineLogCallback(sl::LogType type, const char* msg);
-    static sl::Result hkslInit(sl::Preferences* pref, uint64_t sdkVersion);
-    static sl::Result hkslSetTag(sl::ViewportHandle& viewport, sl::ResourceTag* tags, uint32_t numTags,
-                                 sl::CommandBuffer* cmdBuffer);
-    static void streamlineLogCallback_sl1(sl1::LogType type, const char* msg);
-    static bool hkslInit_sl1(sl1::Preferences* pref, int applicationId);
-    static bool hkslOnPluginLoad(PFN_slOnPluginLoad o_slOnPluginLoad, std::string& config, void* params,
-                                 const char* loaderJSON, const char** pluginJSON);
-    static bool hkdlss_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON);
     static bool hkdlssg_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON);
     static sl::Result hkslDLSSGSetOptions(const sl::ViewportHandle& viewport, const sl::DLSSGOptions& options);
-    static void* hkdlss_slGetPluginFunction(const char* functionName);
     static void* hkdlssg_slGetPluginFunction(const char* functionName);
+
+    // Reflex
+    static sl::ReflexMode reflexGamesLastMode;
+    static PFN_slGetPluginFunction o_reflex_slGetPluginFunction;
+    static PFN_slSetConstants_sl1 o_reflex_slSetConstants_sl1;
+    static PFN_slOnPluginLoad o_reflex_slOnPluginLoad;
+    static decltype(&slReflexSetOptions) o_slReflexSetOptions;
+
+    static bool hkreflex_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON);
+    static sl::Result hkslReflexSetOptions(const sl::ReflexOptions& options);
+    static bool hkreflex_slSetConstants_sl1(const void* data, uint32_t frameIndex, uint32_t id);
+    static void* hkreflex_slGetPluginFunction(const char* functionName);
+
+    // Common
+    static PFN_slGetPluginFunction o_common_slGetPluginFunction;
+    static PFN_slOnPluginLoad o_common_slOnPluginLoad;
+    static PFN_slSetParameters_sl1 o_common_slSetParameters_sl1;
+    static PFN_setVoid o_setVoid;
+
+    static bool hkcommon_slOnPluginLoad(void* params, const char* loaderJSON, const char** pluginJSON);
+    static void* hkcommon_slGetPluginFunction(const char* functionName);
+    static void hkcommon_slSetParameters_sl1(void* params);
+    static bool hk_setVoid(void* self, const char* key, void** value);
+
+    // Logging
+    static char* trimStreamlineLog(const char* msg);
+    static void streamlineLogCallback(sl::LogType type, const char* msg);
+    static void streamlineLogCallback_sl1(sl1::LogType type, const char* msg);
 };

--- a/OptiScaler/include/sl.param/parameters.cpp
+++ b/OptiScaler/include/sl.param/parameters.cpp
@@ -1,0 +1,192 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include <map>
+#include <typeinfo>
+#include <mutex>
+
+#include <sl.h>
+#include "parameters.h"
+
+namespace sl
+{
+
+namespace param
+{
+    
+struct Parameter
+{      
+    template<typename T>
+    void operator=(T value) 
+    { 
+        key = typeid(T).hash_code();  
+        if constexpr (std::is_same<T, float>::value) values.f = value;        
+        else if constexpr (std::is_same<T, int>::value) values.i = value;        
+        else if constexpr (std::is_same<T, unsigned int>::value) values.ui = value;        
+        else if constexpr (std::is_same<T, double>::value) values.d = value;
+        else if constexpr (std::is_same<T, unsigned long long>::value) values.ull = value;
+        else if constexpr (std::is_same<T, void*>::value) values.vp = value;        
+        else if constexpr (std::is_same<T, bool>::value) values.b = value;
+    }
+    
+    template<typename T>
+    operator T() const 
+    { 
+        T v = {};        
+        if constexpr (std::is_same<T, float>::value)
+        {
+            if (key == typeid(unsigned long long).hash_code()) v = (T)values.ull;
+            else if (key == typeid(float).hash_code()) v = (T)values.f;
+            else if (key == typeid(double).hash_code()) v = (T)values.d;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui;
+            else if (key == typeid(int).hash_code()) v = (T)values.i;
+        }
+        else if constexpr (std::is_same<T, int>::value)
+        {
+            if (key == typeid(unsigned long long).hash_code()) v = (T)values.ull;
+            else if (key == typeid(float).hash_code()) v = (T)values.f;
+            else if (key == typeid(double).hash_code()) v = (T)values.d;
+            else if (key == typeid(int).hash_code()) v = (T)values.i;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui;
+        }
+        else if constexpr (std::is_same<T, unsigned int>::value)
+        {
+            if (key == typeid(unsigned long long).hash_code()) v = (T)values.ull;
+            else if (key == typeid(float).hash_code()) v = (T)values.f;
+            else if (key == typeid(double).hash_code()) v = (T)values.d;
+            else if (key == typeid(int).hash_code()) v = (T)values.i;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui;
+        }
+        else if constexpr (std::is_same<T, double>::value)
+        {
+            if (key == typeid(unsigned long long).hash_code()) v = (T)values.ull;
+            else if (key == typeid(float).hash_code()) v = (T)values.f;
+            else if (key == typeid(double).hash_code()) v = (T)values.d;
+            else if (key == typeid(int).hash_code()) v = (T)values.i;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui;
+        }
+        else if constexpr (std::is_same<T, unsigned long long>::value)
+        {
+            if (key == typeid(unsigned long long).hash_code()) v = (T)values.ull;
+            else if (key == typeid(float).hash_code()) v = (T)values.f;
+            else if (key == typeid(double).hash_code()) v = (T)values.d;
+            else if (key == typeid(int).hash_code()) v = (T)values.i;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui;
+            else if (key == typeid(void *).hash_code()) v = (T)values.vp;
+        }
+        else if constexpr (std::is_same<T, void*>::value)
+        {
+            if (key == typeid(void *).hash_code()) v = values.vp;
+        }
+        else if constexpr (std::is_same<T, bool>::value)
+        {
+            if (key == typeid(bool).hash_code()) v = (T)values.b;
+            else if (key == typeid(int).hash_code()) v = (T)values.i != 0;
+            else if (key == typeid(unsigned int).hash_code()) v = (T)values.ui != 0;
+        }
+        return v;
+    }
+    
+    union
+    {
+        bool b;
+        float f;
+        double d;
+        int i;
+        unsigned int ui;
+        unsigned long long ull;
+        void *vp;
+    } values;
+
+    size_t key = 0;
+};
+
+struct Parameters : public IParameters
+{
+    template<typename T>
+    void setT(const char* key, T &value)
+    {
+        const std::lock_guard<std::mutex> lock(m_mutex);
+        m_values[key] = value;
+    }
+
+    void set(const char * key, bool value) override { setT(key, value); }
+    void set(const char * key, unsigned long long value) override { setT(key, value);}
+    void set(const char * key, float value) override { setT(key, value); }
+    void set(const char * key, double value) override { setT(key, value); }
+    void set(const char * key, unsigned int value) override { setT(key, value); }
+    void set(const char * key, int value) override { setT(key, value); }
+    void set(const char * key, void *value) override { setT(key, value); }
+    
+    template<typename T>
+    bool getT(const char* key, T *value) const
+    {
+        const std::lock_guard<std::mutex> lock(m_mutex);
+        auto k = m_values.find(key);
+        if (k == m_values.end()) return false;
+        const Parameter &p = (*k).second;
+        *value = p;
+        return true;
+    }
+
+    bool get(const char * key, bool *value) const override { return getT(key, value); }
+    bool get(const char * key, unsigned long long *value) const override { return getT(key,value); }
+    bool get(const char * key, float *value) const override { return getT(key, value); }
+    bool get(const char * key, double *value) const override { return getT(key, value); }
+    bool get(const char * key, unsigned int *value) const override { return getT(key, value); }
+    bool get(const char * key, int *value) const override { return getT(key, value); }
+    bool get(const char * key, void **value) const override { return getT(key, value); }
+
+    std::vector<std::string> enumerate() const override
+    {
+        std::vector<std::string> keys;
+        for (auto& value : m_values)
+        {
+            keys.push_back(value.first);
+        }
+        return keys;
+    }
+
+    inline static Parameters* s_params = {};
+
+private:
+    std::map<std::string, Parameter> m_values;
+    mutable std::mutex m_mutex;
+};
+
+IParameters *getInterface() 
+{ 
+    if (!Parameters::s_params)
+    {
+        Parameters::s_params = new Parameters();
+    }
+    return Parameters::s_params;
+}
+
+void destroyInterface()
+{
+    delete Parameters::s_params;
+    Parameters::s_params = {};
+}
+
+} // namespace api
+} // namespace sl

--- a/OptiScaler/include/sl.param/parameters.h
+++ b/OptiScaler/include/sl.param/parameters.h
@@ -1,0 +1,202 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include <vector>
+
+namespace sl
+{
+
+// Parameters used to communicate across plugin borders
+
+namespace param
+{
+namespace global
+{
+
+constexpr const char* kColorBuffersHDR = "sl.param.global.colorBuffersHDR";
+constexpr const char* kPFunGetConsts = "sl.param.global.getConstsFunc";
+constexpr const char* kPFunAllocateResource = "sl.param.global.allocateResource";
+constexpr const char* kPFunReleaseResource = "sl.param.global.releaseResource";
+constexpr const char* kPluginPath = "sl.param.global.pluginPath";
+constexpr const char* kLogInterface = "sl.param.global.logInterface";
+constexpr const char* kOTAInterface = "sl.param.global.otaInterface";
+constexpr const char* kNGXContext = "sl.param.global.ngxContext";
+constexpr const char* kNGXContextD3D12 = "sl.param.global.ngxContextD3D12";
+constexpr const char* kDRSContext = "sl.param.global.drsContext";
+constexpr const char* kSwapchainBufferCount = "sl.param.global.swapchainbuffercount";
+constexpr const char* kDebugMode = "sl.param.global.dbgMode";
+constexpr const char* kPFunGetTag = "sl.param.global.getTag";
+constexpr const char* kVulkanTable = "sl.param.global.vulkanTable";
+constexpr const char* kPreferenceFlags = "sl.param.global.prefFlags";
+}
+
+namespace interposer
+{
+constexpr const char* kVKValidationActive = "sl.param.interposer.vkValidationActive";
+}
+
+namespace common
+{
+
+constexpr const char* kSystemCaps = "sl.param.common.gpuInfo";
+constexpr const char* kComputeAPI = "sl.param.common.computeAPI";
+constexpr const char* kComputeDX11On12API = "sl.param.common.computeDX11On12API";
+constexpr const char* kCaptureAPI = "sl.param.common.captureAPI";
+constexpr const char* kKeyboardAPI = "sl.param.common.keyboardAPI";
+constexpr const char* kPFunRegisterEvaluateCallbacks = "sl.param.common.registerEvaluateCallbacks";
+constexpr const char* kPFunGetStringFromModule = "sl.param.common.getStringFromModule";
+constexpr const char* kPFunUpdateCommonEmbeddedJSONConfig = "sl.param.common.updateCommonEmbeddedJSONConfig";
+constexpr const char* kPFunNGXGetFeatureRequirements = "sl.param.common.NGXGetFeatureRequirements";
+constexpr const char* kPFunFindAdapter = "sl.param.common.findAdapter";
+
+}
+
+namespace template_plugin
+{
+
+constexpr const char* kCurrentFrame = "sl.param.template_plugin.frame";
+
+}
+
+namespace dlss_g
+{
+
+constexpr const char* kCurrentFrame = "sl.param.reserved.frame";
+
+}
+
+namespace dlss
+{
+
+constexpr const char* kCurrentFrame = "sl.param.dlss.frame";
+
+}
+
+namespace nis
+{
+
+constexpr const char* kCurrentFrame = "sl.param.nis.frame";
+
+}
+
+namespace latency
+{
+
+constexpr const char* kCurrentFrame = "sl.param.latency.frame";
+constexpr const char* kMarkerPresentFrame = "sl.param.latency.markerPresentFrame";
+//! DEPRECATED (reflex-pcl):
+constexpr const char* kPFunSetLatencyStatsMarker = "sl.param.latency.setLatencyStatsMarker";
+
+}
+
+namespace pcl
+{
+constexpr const char* kPFunSetPCLStatsMarker = "sl.param.pcl.setPCLStatsMarker";
+}
+
+//! DEPRECATED (reflex-pcl):
+//! These should only be used to bridge Reflex and PCL plugins.
+namespace _deprecated_reflex_pcl
+{
+    constexpr const char* kSlSetData = "sl.param._deprecated_reflex_pcl.slSetData";
+    constexpr const char* kSlGetData = "sl.param._deprecated_reflex_pcl.slGetData";
+}
+
+namespace deepDVC
+{
+constexpr const char* kCurrentFrame = "sl.param.deepdvc.frame";
+}
+
+namespace debug_plugin
+{
+constexpr const char* kSetConstsFunc = "sl.param.debug_plugin.setConstsFunc";
+constexpr const char* kGetSettingsFunc = "sl.param.debug_plugin.getSettingsFunc";
+constexpr const char* kStats = "sl.param.debug_plugin.stats";
+constexpr const char* kCurrentFrame = "sl.param.debug_plugin.frame";
+}
+
+namespace imgui
+{
+constexpr const char* kInterface = "sl.param.imgui.interface";
+}
+
+namespace dlss_d
+{
+constexpr const char* kCurrentFrame = "sl.param.dlss_d.frame";
+}
+
+struct IParameters
+{
+    virtual void set(const char* key, bool value) = 0;
+    virtual void set(const char* key, unsigned long long value) = 0;
+    virtual void set(const char* key, float value) = 0;
+    virtual void set(const char* key, double value) = 0;
+    virtual void set(const char* key, unsigned int value) = 0;
+    virtual void set(const char* key, int value) = 0;
+    virtual void set(const char* key, void* value) = 0;
+
+    virtual bool get(const char* key, bool* value) const = 0;
+    virtual bool get(const char* key, unsigned long long* value) const = 0;
+    virtual bool get(const char* key, float* value) const = 0;
+    virtual bool get(const char* key, double* value) const = 0;
+    virtual bool get(const char* key, unsigned int* value) const = 0;
+    virtual bool get(const char* key, int* value) const = 0;
+    virtual bool get(const char* key, void** value) const = 0;
+
+    virtual std::vector<std::string> enumerate() const = 0;
+};
+
+// Helpers
+
+template<typename T>
+inline bool getPointerParam(IParameters* parameters, const char* key, T** res, bool optional = false, uint32_t id = 0)
+{
+    void* p = nullptr;
+    if (!parameters->get(id ? (std::string(key) + "." + std::to_string(id)).c_str() : key, &p))
+    {
+        if (!optional)
+        {
+            return false;
+        }
+    }
+    *res = (T*)p;
+    return true;
+};
+
+template<typename T>
+inline bool getParam(IParameters* parameters, const char* key, T* res, bool optional = false)
+{
+    if (!parameters->get(key, res))
+    {
+        if (!optional)
+        {
+            return false;
+        }
+        *res = {};
+    }
+    return true;
+};
+
+} // namespace param
+} // namespace sl

--- a/OptiScaler/nvapi/ReflexHooks.cpp
+++ b/OptiScaler/nvapi/ReflexHooks.cpp
@@ -200,7 +200,6 @@ void ReflexHooks::update(bool optiFg_FgState, bool isVulkan)
 
     if (_updatesWithoutMarker > 20 || !_inited)
     {
-        LOG_DEBUG("_updatesWithoutMarker: {}, _inited: {}", _updatesWithoutMarker, _inited);
         State::Instance().reflexLimitsFps = false;
         return;
     }

--- a/external/streamline/sl_reflex.h
+++ b/external/streamline/sl_reflex.h
@@ -1,0 +1,220 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/ 
+
+#pragma once
+
+#include "sl_pcl.h"
+
+namespace sl
+{
+
+enum ReflexMode
+{
+    eOff,
+    eLowLatency,
+    eLowLatencyWithBoost,
+
+    // ReflexMode is a C-enum (rather than enum class) so we can't add an eCount value 
+    // without polluting the global namespace (and conflicts with SMSCGMode::eCount in sl.dlss_g/defines.h)
+    ReflexMode_eCount
+};
+
+// {F03AF81A-6D0B-4902-A651-C4965E215434}
+SL_STRUCT_BEGIN(ReflexOptions, StructType({ 0xf03af81a, 0x6d0b, 0x4902, { 0xa6, 0x51, 0xc4, 0x96, 0x5e, 0x21, 0x54, 0x34 } }), kStructVersion1)
+    //! Specifies which mode should be used
+    ReflexMode mode = ReflexMode::eOff;
+    //! Specifies if frame limiting (FPS cap) is enabled (0 to disable, microseconds otherwise).
+    //! One benefit of using Reflex's FPS cap over other implementations is the driver would be aware and can provide better optimizations.
+    //! This setting is independent of ReflexOptions::mode; it can even be used with mode == ReflexMode::eOff.
+    //! The value is used each time you call slReflexSetOptions/slSetData, make sure to initialize when changing one of the other Reflex options during frame limiting.
+    //! It is overridden (ignored) by frameLimitUs if set in sl.reflex.json in non-production builds.
+    uint32_t frameLimitUs = 0;
+    //! This should only be enabled in specific scenarios with subtle caveats.
+    //! Most integrations should leave it unset unless advised otherwise by the Reflex team
+    bool useMarkersToOptimize = false;
+    //! Specifies the hot-key which should be used instead of custom message for PC latency marker
+    //! Possible values: VK_F13, VK_F14, VK_F15
+    uint16_t virtualKey = 0;
+    //! ThreadID for PCL Stats messages
+    uint32_t idThread = 0;
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+SL_STRUCT_END()
+
+// {0D569B37-A1C8-4453-BE4D-40F4DE57952B}
+SL_STRUCT_BEGIN(ReflexReport, StructType({ 0xd569b37, 0xa1c8, 0x4453, { 0xbe, 0x4d, 0x40, 0xf4, 0xde, 0x57, 0x95, 0x2b } }), kStructVersion1)
+    //! Various latency related stats
+    uint64_t frameID{};
+    uint64_t inputSampleTime{};
+    uint64_t simStartTime{};
+    uint64_t simEndTime{};
+    uint64_t renderSubmitStartTime{};
+    uint64_t renderSubmitEndTime{};
+    uint64_t presentStartTime{};
+    uint64_t presentEndTime{};
+    uint64_t driverStartTime{};
+    uint64_t driverEndTime{};
+    uint64_t osRenderQueueStartTime{};
+    uint64_t osRenderQueueEndTime{};
+    uint64_t gpuRenderStartTime{};
+    uint64_t gpuRenderEndTime{};
+    uint32_t gpuActiveRenderTimeUs{};
+    uint32_t gpuFrameTimeUs{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+SL_STRUCT_END()
+
+// {F0BB5985-DAF9-4728-B2FD-AE80A2BD7989}
+SL_STRUCT_BEGIN(ReflexState, StructType({ 0xf0bb5985, 0xdaf9, 0x4728, { 0xb2, 0xfd, 0xae, 0x80, 0xa2, 0xbd, 0x79, 0x89 } }), kStructVersion1)
+    //! Specifies if low-latency mode is available or not
+    bool lowLatencyAvailable = false;
+    //! Specifies if the frameReport below contains valid data or not
+    bool latencyReportAvailable = false;
+    //! Specifies low latency Windows message id (if ReflexOptions::virtualKey is 0)
+    uint32_t statsWindowMessage;
+    //! Reflex report per frame
+    ReflexReport frameReport[64];
+    //! Specifies ownership of flash indicator toggle (true = driver, false = application)
+    bool flashIndicatorDriverControlled = false;
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+SL_STRUCT_END()
+
+// {c83cbb02-b4e2-4260-9ca2-d0c3de3a9684}
+SL_STRUCT_BEGIN(ReflexCameraData, StructType({ 0xc83cbb02, 0xb4e2, 0x4260, { 0x9c, 0xa2, 0xd0, 0xc3, 0xde, 0x3a, 0x96, 0x84 } }), kStructVersion1)
+    float4x4 worldToViewMatrix;
+    float4x4 viewToClipMatrix;
+    float4x4 prevRenderedWorldToViewMatrix;
+    float4x4 prevRenderedViewToClipMatrix;
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+SL_STRUCT_END()
+
+// {8b960090-a807-4c85-b02f-1069950d066c}
+SL_STRUCT_BEGIN(ReflexPredictedCameraData, StructType({ 0x8b960090, 0xa807, 0x4c85, { 0xb0, 0x2f, 0x10, 0x69, 0x95, 0x0d, 0x06, 0x6c } }), kStructVersion1)
+    float4x4 predictedWorldToViewMatrix;
+    float4x4 predictedViewToClipMatrix;
+
+//! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+SL_STRUCT_END()
+
+using MarkerUnderlying = std::underlying_type_t<PCLMarker>;
+
+// {E268B3DC-F963-4C37-9776-AF048E132621}
+SL_STRUCT_BEGIN(ReflexHelper, StructType({ 0xe268b3dc, 0xf963, 0x4c37, { 0x97, 0x76, 0xaf, 0x4, 0x8e, 0x13, 0x26, 0x21 } }), kStructVersion1)
+    ReflexHelper(MarkerUnderlying m) : BaseStructure(ReflexHelper::s_structType, kStructVersion1), marker(m) {};
+    ReflexHelper(PCLMarker m) : BaseStructure(ReflexHelper::s_structType, kStructVersion1), marker(to_underlying(m)) {};
+    operator MarkerUnderlying () const { return marker; };
+private:
+    // May be kReflexMarkerSleep which is not a valid PCLMarker value
+    MarkerUnderlying marker;
+SL_STRUCT_END()
+
+
+}
+
+//! Provides Reflex settings
+//!
+//! Call this method to check if Reflex is on, get stats etc.
+//!
+//! @param state Reference to a structure where states are returned
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe.
+using PFun_slReflexGetState = sl::Result(sl::ReflexState& state);
+
+//! Tells reflex to sleep the app
+//!
+//! Call this method to invoke Reflex sleep in your application.
+//!
+//! @param frame Specifies current frame
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is thread safe.
+using PFun_slReflexSleep = sl::Result(const sl::FrameToken& frame);
+
+//! Sets Reflex options
+//!
+//! Call this method to turn Reflex on/off, change mode etc.
+//!
+//! @param options Specifies options to use
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe.
+using PFun_slReflexSetOptions = sl::Result(const sl::ReflexOptions& options);
+
+//! Sets Reflex camera data
+//!
+//! Call this method to inform Reflex of upcoming camera data
+//!
+//! @param viewport The viewport the camera corresponds to
+//! @param frame The frame to set camera data for
+//! @param inCameraData Camera data for an upcoming render frame
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is thread safe.
+using PFun_slReflexSetCameraData = sl::Result(const sl::ViewportHandle& viewport, const sl::FrameToken& frame, const sl::ReflexCameraData& inCameraData);
+
+//! Gets predicted Reflex camera data
+//!
+//! Call this method to get a prediction of upcoming camera data
+//!
+//! @param viewport The viewport the camera corresponds to
+//! @param frame The frame to get camera data for (if available)
+//! @param outCameraData Predicted Camera data for an upcoming render frame
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is thread safe.
+using PFun_slReflexGetPredictedCameraData = sl::Result(const sl::ViewportHandle& viewport, const sl::FrameToken& frame, sl::ReflexPredictedCameraData& outCameraData);
+
+//! HELPERS
+//! 
+inline sl::Result slReflexGetState(sl::ReflexState& state)
+{
+    SL_FEATURE_FUN_IMPORT_STATIC(sl::kFeatureReflex, slReflexGetState);
+    return s_slReflexGetState(state);
+}
+
+inline sl::Result slReflexSleep(const sl::FrameToken& frame)
+{
+    SL_FEATURE_FUN_IMPORT_STATIC(sl::kFeatureReflex, slReflexSleep);
+    return s_slReflexSleep(frame);
+}
+
+inline sl::Result slReflexSetOptions(const sl::ReflexOptions& options)
+{
+    SL_FEATURE_FUN_IMPORT_STATIC(sl::kFeatureReflex, slReflexSetOptions);
+    return s_slReflexSetOptions(options);
+}
+
+inline sl::Result slReflexSetCameraData(const sl::ViewportHandle& viewport, const sl::FrameToken& frame, const sl::ReflexCameraData& inCameraData)
+{
+    SL_FEATURE_FUN_IMPORT_STATIC(sl::kFeatureReflex, slReflexSetCameraData);
+    return s_slReflexSetCameraData(viewport, frame, inCameraData);
+}
+
+inline sl::Result slReflexGetPredictedCameraData(const sl::ViewportHandle& viewport, const sl::FrameToken& frame, sl::ReflexPredictedCameraData& outCameraData)
+{
+    SL_FEATURE_FUN_IMPORT_STATIC(sl::kFeatureReflex, slReflexGetPredictedCameraData);
+    return s_slReflexGetPredictedCameraData(viewport, frame, outCameraData);
+}
+

--- a/external/streamline1/sl1_reflex.h
+++ b/external/streamline1/sl1_reflex.h
@@ -1,0 +1,102 @@
+/*
+* Copyright (c) 2022 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/ 
+
+#pragma once
+
+namespace sl1
+{
+
+enum ReflexMode
+{
+    eReflexModeOff,
+    eReflexModeLowLatency,
+    eReflexModeLowLatencyWithBoost,
+};
+
+struct ReflexConstants
+{
+    //! Specifies which mode should be used
+    ReflexMode mode = eReflexModeOff;
+    //! Specifies if frame limiting is enabled (0 to disable, microseconds otherwise)
+    uint32_t frameLimitUs = 0;
+    //! Specifies if markers are used or not (this should always be true and markers should be placed correctly)
+    bool useMarkersToOptimize = false;
+    //! Specifies the hot-key which should be used instead of custom message for PC latency marker
+    //! Possible values: VK_F13, VK_F14, VK_F15
+    uint16_t virtualKey = 0;
+    //! Reserved for future expansion, must be set to null
+    void* ext = {};
+};
+
+struct ReflexReport
+{
+    //! Various latency related stats
+    uint64_t frameID{};
+    uint64_t inputSampleTime{};
+    uint64_t simStartTime{};
+    uint64_t simEndTime{};
+    uint64_t renderSubmitStartTime{};
+    uint64_t renderSubmitEndTime{};
+    uint64_t presentStartTime{};
+    uint64_t presentEndTime{};
+    uint64_t driverStartTime{};
+    uint64_t driverEndTime{};
+    uint64_t osRenderQueueStartTime{};
+    uint64_t osRenderQueueEndTime{};
+    uint64_t gpuRenderStartTime{};
+    uint64_t gpuRenderEndTime{};
+    uint32_t gpuActiveRenderTimeUs{};
+    uint32_t gpuFrameTimeUs{};
+};
+
+struct ReflexSettings
+{
+    //! Specifies if low-latency mode is available or not
+    bool lowLatencyAvailable = false;
+    //! Specifies if latency report is available or not
+    bool latencyReportAvailable = false;
+    //! Specifies low latency Windows message id (if ReflexConstants::virtualKey is 0)
+    uint32_t statsWindowMessage;
+    //! Reflex report per frame
+    ReflexReport frameReport[64];
+    //! Specifies ownership of flash indicator toggle (true = driver, false = application)
+    bool flashIndicatorDriverControlled = false;    
+    //! Reserved for future expansion, must be set to null
+    void* ext = {};
+};
+
+enum ReflexMarker
+{
+    eReflexMarkerSimulationStart,
+    eReflexMarkerSimulationEnd,
+    eReflexMarkerRenderSubmitStart,
+    eReflexMarkerRenderSubmitEnd,
+    eReflexMarkerPresentStart,
+    eReflexMarkerPresentEnd,
+    eReflexMarkerInputSample,
+    eReflexMarkerTriggerFlash,    
+    eReflexMarkerPCLatencyPing,
+    //! Special marker
+    eReflexMarkerSleep = 0x1000,
+};
+
+}


### PR DESCRIPTION
It is enabled by default so in some cases users should see DLSS, DLSSG and/or Reflex show up even with Dxgi spoofing disabled.

Reflex can often be force enabled if fakenvapi is added, even if the game settings don't allow for activating it. But the results vary.