### PR TITLE
feat: create amd/intel specific release with fakenvapi and dlssg-to-fsr3

### DIFF
--- a/.github/workflows/just_build.yml
+++ b/.github/workflows/just_build.yml
@@ -192,17 +192,51 @@ jobs:
         Write-Output "Successfully copied nvapi64.dll and fakenvapi.ini to artifact directory"
       continue-on-error: false
     
-    - name: Compress the artifact 
+    # Create NVIDIA version (without external files)
+    - name: Create NVIDIA version (without external files)
+      shell: powershell
       run: |
-        $zipName = "${{ steps.get_version.outputs.filename }}.7z"
-        7z a -r ${{ github.workspace }}\$zipName ${{ github.workspace }}\x64\Release\a\*.*
-
-      continue-on-error: false
+        # Create a copy of the artifact directory for NVIDIA version
+        $nvidiaDir = "${{ github.workspace }}\x64\Release\nvidia"
         
+        # Create directory and copy all files
+        New-Item -ItemType Directory -Path $nvidiaDir -Force
+        Copy-Item -Path "${{ github.workspace }}\x64\Release\a\*" -Destination $nvidiaDir -Recurse -Force
+        
+        # Remove the external files that should not be in the NVIDIA version
+        Remove-Item -Path "$nvidiaDir\dlssg_to_fsr3_amd_is_better.dll" -ErrorAction SilentlyContinue
+        Remove-Item -Path "$nvidiaDir\fakenvapi.ini" -ErrorAction SilentlyContinue
+        Remove-Item -Path "$nvidiaDir\nvapi64.dll" -ErrorAction SilentlyContinue
+        
+        Write-Output "Successfully created NVIDIA version directory without external files"
+    
+    # Compress AMD version (with all files)
+    - name: Compress AMD artifact 
+      run: |
+        $zipName = "${{ steps.get_version.outputs.filename }}_amd.7z"
+        7z a -r ${{ github.workspace }}\$zipName ${{ github.workspace }}\x64\Release\a\*.*
+      continue-on-error: false
+    
+    # Compress NVIDIA version (without external files)
+    - name: Compress NVIDIA artifact
+      run: |
+        $zipName = "${{ steps.get_version.outputs.filename }}_nvidia.7z"
+        7z a -r ${{ github.workspace }}\$zipName ${{ github.workspace }}\x64\Release\nvidia\*.*
+      continue-on-error: false
+    
+    # Upload AMD version
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ steps.get_version.outputs.filename }}
-        path: ${{ github.workspace }}\${{ steps.get_version.outputs.filename }}.7z
+        name: ${{ steps.get_version.outputs.filename }}_amd
+        path: ${{ github.workspace }}\${{ steps.get_version.outputs.filename }}_amd.7z
+        compression-level: 0
+        if-no-files-found: error
+    
+    # Upload NVIDIA version
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.get_version.outputs.filename }}_nvidia
+        path: ${{ github.workspace }}\${{ steps.get_version.outputs.filename }}_nvidia.7z
         compression-level: 0
         if-no-files-found: error
 

--- a/.github/workflows/just_build.yml
+++ b/.github/workflows/just_build.yml
@@ -7,8 +7,8 @@ name: Build
 
 on:
   workflow_dispatch:
-#  push:
-#    branches: [ "master" ]
+  push:
+    branches: [ "bundle-externals" ]
 #  pull_request:
 #    branches: [ "master" ]
     
@@ -99,6 +99,50 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /verbosity:minimal
       
+    - name: Download latest dlssg-to-fsr3 release
+      id: dlssg_download
+      shell: powershell
+      run: |
+        # Get the latest release info from the API
+        $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/xXJSONDeruloXx/dlssg-to-fsr3/releases/latest"
+        
+        # Find the standard ZIP asset (not Universal or DLSSTweaks.Edition)
+        $asset = $releases.assets | Where-Object { 
+          $_.name -like "dlssg-to-fsr3-*.zip" -and 
+          $_.name -notlike "*Universal*" -and 
+          $_.name -notlike "*DLSSTweaks.Edition*" 
+        } | Select-Object -First 1
+        
+        if (-not $asset) {
+            Write-Error "Could not find appropriate dlssg-to-fsr3 release asset"
+            exit 1
+        }
+        
+        Write-Output "Downloading $($asset.name)..."
+        
+        # Download the asset
+        $downloadUrl = $asset.browser_download_url
+        $zipPath = "${{ github.workspace }}\dlssg-to-fsr3.zip"
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+        
+        # Extract the ZIP file
+        $extractPath = "${{ github.workspace }}\dlssg-temp"
+        Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+        
+        # Find the DLL file in the extracted directory
+        $dllPath = Get-ChildItem -Path $extractPath -Recurse -Filter "dlssg_to_fsr3_amd_is_better.dll" | Select-Object -First 1 -ExpandProperty FullName
+        
+        if (-not $dllPath) {
+            Write-Error "Could not find dlssg_to_fsr3_amd_is_better.dll in the extracted files"
+            exit 1
+        }
+        
+        # Copy the DLL to the artifact directory
+        Copy-Item -Path $dllPath -Destination "${{ github.workspace }}\x64\Release\a\"
+        
+        Write-Output "Successfully copied dlssg_to_fsr3_amd_is_better.dll to artifact directory"
+      continue-on-error: false
+    
     - name: Compress the artifact 
       run: |
         $zipName = "${{ steps.get_version.outputs.filename }}.7z"
@@ -112,6 +156,6 @@ jobs:
         path: ${{ github.workspace }}\${{ steps.get_version.outputs.filename }}.7z
         compression-level: 0
         if-no-files-found: error
-        
+
 
 

--- a/.github/workflows/just_build.yml
+++ b/.github/workflows/just_build.yml
@@ -7,8 +7,8 @@ name: Build
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ "bundle-externals" ]
+# push:
+#   branches: [ "master" ]
 #  pull_request:
 #    branches: [ "master" ]
     

--- a/.github/workflows/just_build.yml
+++ b/.github/workflows/just_build.yml
@@ -143,6 +143,55 @@ jobs:
         Write-Output "Successfully copied dlssg_to_fsr3_amd_is_better.dll to artifact directory"
       continue-on-error: false
     
+    - name: Download latest fakenvapi release
+      id: fakenvapi_download
+      shell: powershell
+      run: |
+        # Get the latest release info from the API
+        $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/FakeMichau/fakenvapi/releases/latest"
+        
+        # Find the fakenvapi.zip asset
+        $asset = $releases.assets | Where-Object { 
+          $_.name -eq "fakenvapi.zip"
+        } | Select-Object -First 1
+        
+        if (-not $asset) {
+            Write-Error "Could not find fakenvapi.zip in the latest release"
+            exit 1
+        }
+        
+        Write-Output "Downloading $($asset.name)..."
+        
+        # Download the asset
+        $downloadUrl = $asset.browser_download_url
+        $zipPath = "${{ github.workspace }}\fakenvapi.zip"
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+        
+        # Extract the ZIP file
+        $extractPath = "${{ github.workspace }}\fakenvapi-temp"
+        Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+        
+        # Find the required files in the extracted directory
+        $nvapi64Path = Get-ChildItem -Path $extractPath -Recurse -Filter "nvapi64.dll" | Select-Object -First 1 -ExpandProperty FullName
+        $fakenvApiIniPath = Get-ChildItem -Path $extractPath -Recurse -Filter "fakenvapi.ini" | Select-Object -First 1 -ExpandProperty FullName
+        
+        if (-not $nvapi64Path) {
+            Write-Error "Could not find nvapi64.dll in the extracted files"
+            exit 1
+        }
+        
+        if (-not $fakenvApiIniPath) {
+            Write-Error "Could not find fakenvapi.ini in the extracted files"
+            exit 1
+        }
+        
+        # Copy the files to the artifact directory
+        Copy-Item -Path $nvapi64Path -Destination "${{ github.workspace }}\x64\Release\a\"
+        Copy-Item -Path $fakenvApiIniPath -Destination "${{ github.workspace }}\x64\Release\a\"
+        
+        Write-Output "Successfully copied nvapi64.dll and fakenvapi.ini to artifact directory"
+      continue-on-error: false
+    
     - name: Compress the artifact 
       run: |
         $zipName = "${{ steps.get_version.outputs.filename }}.7z"

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -253,6 +253,7 @@ copy $(SolutionDir)external\FidelityFX-SDK\docs\license.md $(SolutionDir)x64\Rel
 copy $(SolutionDir)external\FidelityFX-SDK\PrebuiltSignedDLL\*.dll $(SolutionDir)x64\Release\a\ /Y
 copy $(SolutionDir)OptiScaler.ini $(SolutionDir)x64\Release\a\ /Y
 copy "$(SolutionDir)OptiScaler Setup.bat" $(SolutionDir)x64\Release\a\ /Y
+copy "$(SolutionDir)optiscaler_setup.sh" $(SolutionDir)x64\Release\a\ /Y
 md $(SolutionDir)x64\Release\a\D3D12_Optiscaler\
 copy "$(SolutionDir)external\directx_agility_sdk\lib\*.dll" $(SolutionDir)x64\Release\a\D3D12_Optiscaler\ /Y
 copy "$(SolutionDir)external\directx_agility_sdk\LICENSE.txt" $(SolutionDir)x64\Release\a\D3D12_Optiscaler\LICENSE.txt /Y


### PR DESCRIPTION
This PR modifies the GitHub Actions build workflow to create two separate versions of OptiScaler:

### 1. AMD Version (`OptiScaler_[version]_[date]_amd.7z`)
- Includes all standard OptiScaler files
- Automatically bundles the latest releases of two important external dependencies:
  - `dlssg_to_fsr3_amd_is_better.dll` from [xXJSONDeruloXx/dlssg-to-fsr3](https://github.com/xXJSONDeruloXx/dlssg-to-fsr3) (standard release, not Universal or DLSSTweaks.Edition)
  - `nvapi64.dll` and `fakenvapi.ini` from [FakeMichau/fakenvapi](https://github.com/FakeMichau/fakenvapi)

### 2. NVIDIA Version (`OptiScaler_[version]_[date]_nvidia.7z`)
- Includes all standard OptiScaler files
- Excludes the AMD-specific external dependencies

## Additional Improvements
- Added Linux setup script (`optiscaler_setup.sh`) to both packages
- Automated the process of fetching the latest releases of external dependencies
- Simplified user experience by eliminating the need to download additional files separately

## Benefits
- **Simplified Installation**: Users now have a complete package ready to use
- **Cross-Platform Support**: Both Windows and Linux users are properly supported
- **Version-Appropriate Packages**: NVIDIA users get a cleaner package without unnecessary AMD-specific files
- **Automatic Updates**: Each build automatically includes the latest versions of external dependencies

## How It Works
The workflow dynamically fetches the latest releases from both external repositories using the GitHub API, extracts the required files, and includes them in the AMD version of the package. For the NVIDIA version, it creates a copy of the artifact directory without these specific files.