### PR TITLE
Null check lpSubKey before comparing it.

### DIFF
--- a/OptiScaler/hooks/Advapi32_Hooks.h
+++ b/OptiScaler/hooks/Advapi32_Hooks.h
@@ -21,7 +21,7 @@ static LSTATUS hkRegOpenKeyExW(HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REG
 {
     LSTATUS result = 0;
 
-    if (wcscmp(L"SOFTWARE\\NVIDIA Corporation\\Global", lpSubKey) == 0)
+    if (lpSubKey != nullptr && wcscmp(L"SOFTWARE\\NVIDIA Corporation\\Global", lpSubKey) == 0)
     {
         *phkResult = signatureMark;
         return 0;


### PR DESCRIPTION
Fixes crashes on certain FFXIV plugins. 