### PR TITLE
Remove the need for amdxc64 on Linux

### DIFF
--- a/OptiScaler/FSR4Upgrade.h
+++ b/OptiScaler/FSR4Upgrade.h
@@ -342,7 +342,7 @@ static inline void CheckForGPU()
             {
                 // If GPU Name contains 90XX or GFX12 (Linux) always set it to true
                 if (szName.find(L" 90") != std::wstring::npos || szName.find(L" GFX12") != std::wstring::npos)
-                    Config::Instance()->Fsr4Update = true;
+                    Config::Instance()->Fsr4Update.set_volatile_value(true);
             }
         }
         else
@@ -357,9 +357,6 @@ static inline void CheckForGPU()
 
     factory->Release();
     factory = nullptr;
-
-    if (!Config::Instance()->Fsr4Update.has_value())
-        Config::Instance()->Fsr4Update = false;
 
     LOG_INFO("Fsr4Update: {}", Config::Instance()->Fsr4Update.value_or_default());
 }
@@ -387,6 +384,25 @@ inline static HRESULT STDMETHODCALLTYPE hkAmdExtD3DCreateInterface(IUnknown* pOu
 
     if (o_AmdExtD3DCreateInterface != nullptr)
         return o_AmdExtD3DCreateInterface(pOuter, riid, ppvObject);
+
+    return E_NOINTERFACE;
+}
+
+inline static HRESULT STDMETHODCALLTYPE customAmdExtD3DCreateInterface(IUnknown* pOuter, REFIID riid, void** ppvObject)
+{
+    // If querying IAmdExtFfxApi
+    if (riid == __uuidof(IAmdExtFfxApi))
+    {
+        if (_amdExtFfxApi == nullptr)
+            _amdExtFfxApi = new AmdExtFfxApi();
+
+        // Return custom one
+        *ppvObject = _amdExtFfxApi;
+
+        LOG_INFO("Custom IAmdExtFfxApi queried, returning custom AmdExtFfxApi");
+
+        return S_OK;
+    }
 
     return E_NOINTERFACE;
 }


### PR DESCRIPTION
amdxcffx64.dll is still needed, it contains the FSR 4 itself.