### PR TITLE
Fix menu rendering under Vulkan (and Linux/Wine in general)

### DIFF
--- a/OptiScaler/menu/menu_overlay_vk.cpp
+++ b/OptiScaler/menu/menu_overlay_vk.cpp
@@ -150,11 +150,11 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
 
         attachment_desc.format = pCreateInfo->imageFormat;
         attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
         attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
         attachment_desc.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
         VkAttachmentReference color_attachment = {};


### PR DESCRIPTION
As we actually care about the existing data of the swapchain image use `VK_ATTACHMENT_LOAD_OP_LOAD` for the render pass.
Under Linux/Wine OptiScaler seems to render the overlay menu via Vulkan even in Games using D3D12 (vkd3d-proton).

Tested Cyberpunk 2077 and DOOM: The Dark Ages on Linux/Wine with an AMD Radeon RX 7800 XT (using Mesa 25.1.7).

I guess it would be nice if someone tested this change with a Vulkan game under Windows, even though I don't expect doing the right thing to break anything.

Fixes #452