### PR TITLE
setup_linux.sh: Use more generic bash

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clear
 
@@ -206,7 +206,7 @@ fi
 # Create uninstaller
 create_uninstaller() {
     cat > "remove_optiscaler.sh" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 clear
 echo " ::::::::  :::::::::  ::::::::::: :::::::::::  ::::::::   ::::::::      :::     :::        :::::::::: :::::::::  "


### PR DESCRIPTION
Maybe need more users test, but I tested on Nixos, and it works also on Archlinux.

On NixOS, /bin/bash not exist at all, and it's recommended to use /usr/bin/env bash. 
This executable exists also on Archlinux and normally exist on all Linux distributions.