### PR TITLE
feat: make linux setup script take args for various automation projects

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -265,8 +265,20 @@ create_uninstaller() {
     cat > "remove_optiscaler.sh" << 'EOF'
 #!/usr/bin/env bash
 
+show_help() {
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --remove=<y|n>    Confirm removal (y/n)"
+    echo "  -h, --help        Show this help message"
+    echo ""
+    exit 0
+}
+
 for arg in "$@"; do
     case "$arg" in
+        -h|--help) show_help ;;
         --remove=*) remove_choice="${arg#*=}" ;;
     esac
 done
@@ -313,7 +325,9 @@ else
     echo ""
 fi
 
-read -p "Press Enter to exit..."
+if [ $# -eq 0 ]; then
+    read -p "Press Enter to exit..."
+fi
 EOF
 
     # Replace the placeholder with the actual selected filename


### PR DESCRIPTION
Adding the ability to pass in some args to the `linux_setup.sh` script to better facilitate various projects that attempt to automate OptiScaler installation (Decky Framegen, Goverlay, ProtonPlus etc).

Currently, each program needs its own logic or bespoke installation and removal scripting, but if this is built into the upstream script, then these programs can just worry about getting all the opti files into the correct dir in the game, then run something like:

`./setup_linux.sh --filename=dxgi.dll --overwrite=y --using_nvidia=n --using_dlss=y`

Which greatly simplifies Opti integration in a variety of linux tools. 
