### PR TITLE
Direct XeLL Frame Limiter instead of Reflex Limiter -> XeLL Limiter conversion 

### DIFF
--- a/OptiScaler/hooks/Reflex_Hooks.cpp
+++ b/OptiScaler/hooks/Reflex_Hooks.cpp
@@ -417,7 +417,12 @@ void ReflexHooks::setFPSLimit(float fps)
         NV_SET_SLEEP_MODE_PARAMS temp {};
         memcpy(&temp, &_lastSleepParams, sizeof(NV_SET_SLEEP_MODE_PARAMS));
         temp.minimumIntervalUs = _minimumIntervalUs;
-        o_NvAPI_D3D_SetSleepMode(_lastSleepDev, &temp);
+
+        if (State::Instance().activeFgOutput == FGOutput::XeFG && fakenvapi::ForNvidia_SetSleepMode)
+            fakenvapi::ForNvidia_SetSleepMode(_lastSleepDev, &temp);
+        else
+            o_NvAPI_D3D_SetSleepMode(_lastSleepDev, &temp);
+
     }
 
     if (_lastVkSleepDev != nullptr)


### PR DESCRIPTION
Reflex Limiter -> XeLL Limiter (Sleep Mode) adds latency. Setting the XeLL Limiter directly fixes that.
<img width="401" height="77" alt="Spider-Man_KowU2PJakW" src="https://github.com/user-attachments/assets/219bc316-9f36-4533-b3aa-62e6cdf5b69f" />
