### PR TITLE
Fix FPS limit not working for DX11 games with Frame Generation

### DIFF
--- a/OptiScaler/wrapped/wrapped_swapchain.cpp
+++ b/OptiScaler/wrapped/wrapped_swapchain.cpp
@@ -489,8 +489,13 @@ HRESULT STDMETHODCALLTYPE WrappedIDXGISwapChain4::Present(UINT SyncInterval, UIN
         result = LocalPresent(_real, SyncInterval, Flags, nullptr, _device, _handle, _uwp);
 
         // When Reflex can't be used to limit, sleep in present
-        if (!State::Instance().reflexLimitsFps && State::Instance().activeFgOutput == FGOutput::NoFG)
-            FrameLimit::sleep(false);
+        // For DX11 games with FG (Dx11withDx12), there's no separate FG swapchain,
+        // so we need to limit here even when FG is active
+        if (!State::Instance().reflexLimitsFps && (State::Instance().activeFgOutput == FGOutput::NoFG ||
+            State::Instance().currentFGSwapchain == nullptr))
+        {
+            FrameLimit::sleep(State::Instance().currentFG != nullptr && State::Instance().currentFG->IsActive());
+        }
     }
     else
     {
@@ -771,8 +776,13 @@ HRESULT STDMETHODCALLTYPE WrappedIDXGISwapChain4::Present1(UINT SyncInterval, UI
         result = LocalPresent(_real1, SyncInterval, Flags, pPresentParameters, _device, _handle, _uwp);
 
         // When Reflex can't be used to limit, sleep in present
-        if (!State::Instance().reflexLimitsFps && State::Instance().activeFgOutput == FGOutput::NoFG)
-            FrameLimit::sleep(false);
+        // For DX11 games with FG (Dx11withDx12), there's no separate FG swapchain,
+        // so we need to limit here even when FG is active
+        if (!State::Instance().reflexLimitsFps && (State::Instance().activeFgOutput == FGOutput::NoFG ||
+            State::Instance().currentFGSwapchain == nullptr))
+        {
+            FrameLimit::sleep(State::Instance().currentFG != nullptr && State::Instance().currentFG->IsActive());
+        }
     }
     else
     {


### PR DESCRIPTION
For DX11 games using FG through Dx11withDx12 mode, there's no separate FG swapchain created. The previous condition only applied FPS limiting when activeFgOutput == FGOutput::NoFG, which excluded DX11+FG games.

Now checks if currentFGSwapchain is nullptr to handle DX11 games with FG, and passes the correct fgActive flag to FrameLimit::sleep() for proper frame interval calculation when FG is active.