### PR TITLE
Fix NGX Lifetime Management and Manual FSR FOV Conversion

### DIFF
--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -350,9 +350,9 @@ class Config
     CustomOptional<bool> DontCreateD3D12DeviceForLuma { false };
 
     // Upscalers
-    CustomOptional<std::string, SoftDefault> Dx11Upscaler { "fsr22" };
-    CustomOptional<std::string, SoftDefault> Dx12Upscaler { "xess" };
-    CustomOptional<std::string, SoftDefault> VulkanUpscaler { "fsr22" };
+    CustomOptional<std::string, SoftDefault> Dx11Upscaler { std::string(OptiKeys::FSR22) };
+    CustomOptional<std::string, SoftDefault> Dx12Upscaler { std::string(OptiKeys::XeSS) };
+    CustomOptional<std::string, SoftDefault> VulkanUpscaler { std::string(OptiKeys::FSR21) };
 
     // Output Scaling
     CustomOptional<bool> OutputScalingEnabled { false };

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -352,7 +352,7 @@ class Config
     // Upscalers
     CustomOptional<std::string, SoftDefault> Dx11Upscaler { std::string(OptiKeys::FSR22) };
     CustomOptional<std::string, SoftDefault> Dx12Upscaler { std::string(OptiKeys::XeSS) };
-    CustomOptional<std::string, SoftDefault> VulkanUpscaler { std::string(OptiKeys::FSR21) };
+    CustomOptional<std::string, SoftDefault> VulkanUpscaler { std::string(OptiKeys::FSR22) };
 
     // Output Scaling
     CustomOptional<bool> OutputScalingEnabled { false };

--- a/OptiScaler/MathUtils.h
+++ b/OptiScaler/MathUtils.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <numbers>
+#include <cmath>
+
+namespace OptiMath
+{
+    // Radians per degree. Used to convert from degrees to radians
+    inline constexpr float DegToRad = std::numbers::pi_v<float> / 180.0f;
+    // Degrees per radian. Used to convert from radians to degrees
+    inline constexpr float RadToDeg = 180.0f / std::numbers::pi_v<float>;
+
+    // Converts from an angle in degrees to radians
+    [[nodiscard]] inline constexpr float GetRadiansFromDeg(const float deg) { return deg * DegToRad; }
+
+    // Converts from an angle in radians to degrees
+    [[nodiscard]] inline constexpr float GetDegreesFromRad(const float rad) { return rad * RadToDeg; }
+
+    /**
+     * @brief Calculates the vertical field of view for a camera from its horizontal FOV and its
+     * viewport dimensions according to the formula: vFov = 2 * arctan( tan( hFov / 2 ) * ( h / w ) ).
+     * @param hFovRad: Horizontal field of view
+     * @param width: Width of the camera viewport
+     * @param height: Height of the camera viewport
+     * @return Vertical FOV in radians
+     */
+    [[nodiscard]] inline float GetVerticalFovFromHorizontal(const float hFovRad, const float width, const float height)
+    {
+        if (width <= 0.0f) return 0.0f;
+        return 2.0f * std::atan(std::tan(hFovRad * 0.5f) * (height / width));
+    }
+
+    /**
+     * @brief Calculates the horizontal field of view for a camera from its vertical FOV and its
+     * viewport dimensions according to the formula: hFov = 2 * arctan( tan( vFov / 2 ) * ( w / h ) ).
+     * @param vFovRad: Vertical field of view in radians
+     * @param width: Width of the camera viewport
+     * @param height: Height of the camera viewport
+     * @return Horizontal FOV in radians
+     */
+    [[nodiscard]] inline float GetHorizontalFovFromVertical(const float vFovRad, const float width, const float height)
+    {
+        if (height <= 0.0f) return 0.0f;
+        return 2.0f * std::atan(std::tan(vFovRad * 0.5f) * (width / height));
+    }
+}

--- a/OptiScaler/MathUtils.h
+++ b/OptiScaler/MathUtils.h
@@ -4,42 +4,44 @@
 
 namespace OptiMath
 {
-    // Radians per degree. Used to convert from degrees to radians
-    inline constexpr float DegToRad = std::numbers::pi_v<float> / 180.0f;
-    // Degrees per radian. Used to convert from radians to degrees
-    inline constexpr float RadToDeg = 180.0f / std::numbers::pi_v<float>;
+// Radians per degree. Used to convert from degrees to radians
+inline constexpr float DegToRad = std::numbers::pi_v<float> / 180.0f;
+// Degrees per radian. Used to convert from radians to degrees
+inline constexpr float RadToDeg = 180.0f / std::numbers::pi_v<float>;
 
-    // Converts from an angle in degrees to radians
-    [[nodiscard]] inline constexpr float GetRadiansFromDeg(const float deg) { return deg * DegToRad; }
+// Converts from an angle in degrees to radians
+[[nodiscard]] inline constexpr float GetRadiansFromDeg(const float deg) { return deg * DegToRad; }
 
-    // Converts from an angle in radians to degrees
-    [[nodiscard]] inline constexpr float GetDegreesFromRad(const float rad) { return rad * RadToDeg; }
+// Converts from an angle in radians to degrees
+[[nodiscard]] inline constexpr float GetDegreesFromRad(const float rad) { return rad * RadToDeg; }
 
-    /**
-     * @brief Calculates the vertical field of view for a camera from its horizontal FOV and its
-     * viewport dimensions according to the formula: vFov = 2 * arctan( tan( hFov / 2 ) * ( h / w ) ).
-     * @param hFovRad: Horizontal field of view
-     * @param width: Width of the camera viewport
-     * @param height: Height of the camera viewport
-     * @return Vertical FOV in radians
-     */
-    [[nodiscard]] inline float GetVerticalFovFromHorizontal(const float hFovRad, const float width, const float height)
-    {
-        if (width <= 0.0f) return 0.0f;
-        return 2.0f * std::atan(std::tan(hFovRad * 0.5f) * (height / width));
-    }
-
-    /**
-     * @brief Calculates the horizontal field of view for a camera from its vertical FOV and its
-     * viewport dimensions according to the formula: hFov = 2 * arctan( tan( vFov / 2 ) * ( w / h ) ).
-     * @param vFovRad: Vertical field of view in radians
-     * @param width: Width of the camera viewport
-     * @param height: Height of the camera viewport
-     * @return Horizontal FOV in radians
-     */
-    [[nodiscard]] inline float GetHorizontalFovFromVertical(const float vFovRad, const float width, const float height)
-    {
-        if (height <= 0.0f) return 0.0f;
-        return 2.0f * std::atan(std::tan(vFovRad * 0.5f) * (width / height));
-    }
+/**
+ * @brief Calculates the vertical field of view for a camera from its horizontal FOV and its
+ * viewport dimensions according to the formula: vFov = 2 * arctan( tan( hFov / 2 ) * ( h / w ) ).
+ * @param hFovRad: Horizontal field of view
+ * @param width: Width of the camera viewport
+ * @param height: Height of the camera viewport
+ * @return Vertical FOV in radians
+ */
+[[nodiscard]] inline float GetVerticalFovFromHorizontal(const float hFovRad, const float width, const float height)
+{
+    if (width <= 0.0f)
+        return 0.0f;
+    return 2.0f * std::atan(std::tan(hFovRad * 0.5f) * (height / width));
 }
+
+/**
+ * @brief Calculates the horizontal field of view for a camera from its vertical FOV and its
+ * viewport dimensions according to the formula: hFov = 2 * arctan( tan( vFov / 2 ) * ( w / h ) ).
+ * @param vFovRad: Vertical field of view in radians
+ * @param width: Width of the camera viewport
+ * @param height: Height of the camera viewport
+ * @return Horizontal FOV in radians
+ */
+[[nodiscard]] inline float GetHorizontalFovFromVertical(const float vFovRad, const float width, const float height)
+{
+    if (height <= 0.0f)
+        return 0.0f;
+    return 2.0f * std::atan(std::tan(vFovRad * 0.5f) * (width / height));
+}
+} // namespace OptiMath

--- a/OptiScaler/NVNGX_Parameter.h
+++ b/OptiScaler/NVNGX_Parameter.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "SysUtils.h"
-
 #include "Config.h"
-
 #include <ankerl/unordered_dense.h>
 
 // Use real NVNGX params encapsulated in custom one
@@ -17,6 +15,24 @@
 #else
 #define LOG_PARAM(msg, ...)
 #endif
+
+/** @brief Indicates the lifetime management required by an NGX parameter table. */
+namespace NGX_AllocTypes
+{
+    // Key used to get/set enum from table
+    constexpr std::string_view AllocKey = "OptiScaler.ParamAllocType";
+
+    constexpr uint32_t Unknown = 0;
+    // Standard behavior in modern DLSS. Created with NGX Allocate(). Freed with Destroy().
+    constexpr uint32_t NVDynamic = 1;
+    // Legacy DLSS. Lifetime managed internally by the SDK.
+    constexpr uint32_t NVPersistent = 2;
+    // OptiScaler implementation used internally with new/delete.
+    constexpr uint32_t InternDynamic = 3;
+    // OptiScaler implementation for legacy applications. Must maintain a persistent instance
+    // for the lifetime of the application.
+    constexpr uint32_t InternPersistent = 4;
+}
 
 /// @brief Calculates the resolution scaling ratio override based on the provided quality level and current
 /// configuration.
@@ -670,6 +686,17 @@ struct NVNGX_Parameters : public NVSDK_NGX_Parameter
 {
     std::string Name;
 
+    NVNGX_Parameters(std::string_view name, bool isPersistent) :
+        Name(name)
+    { 
+        // Old flag used to indicate custom table. Obsolete?
+        Set("OptiScaler", 1);
+        // New tracking flag
+        Set(NGX_AllocTypes::AllocKey.data(), isPersistent ? 
+            NGX_AllocTypes::InternPersistent : 
+            NGX_AllocTypes::InternDynamic);
+    }
+
 #ifdef ENABLE_ENCAPSULATED_PARAMS
     NVSDK_NGX_Parameter* OriginalParam = nullptr;
 #endif // ENABLE_ENCAPSULATED_PARAMS
@@ -981,13 +1008,64 @@ struct NVNGX_Parameters : public NVSDK_NGX_Parameter
     }
 };
 
-/// @brief Allocates and populates a new NGX param map.
-inline static NVNGX_Parameters* GetNGXParameters(std::string InName)
+/**
+ * @brief Allocates and populates a new custom NGX param map. The persistence flag indicates
+ * whether the table should be destroyed when NGX DestroyParameters() is used.
+ */
+inline static NVNGX_Parameters* GetNGXParameters(std::string_view name, bool isPersistent)
 {
-    auto params = new NVNGX_Parameters();
-    params->Name = InName;
+    auto params = new NVNGX_Parameters(name, isPersistent);
     InitNGXParameters(params);
-    params->Set("OptiScaler", 1);
-
     return params;
+}
+
+/**
+ * @brief Sets a custom tracking tag to indicate the memory management strategy required by 
+ * the table, indicated by NGX_AllocTypes.
+ */
+inline static void SetNGXParamAllocType(NVSDK_NGX_Parameter& params, uint32_t allocType)
+{
+    params.Set(NGX_AllocTypes::AllocKey.data(), allocType);
+}
+
+/**
+ * @brief Attempts to safely delete an NGX parameter table. Dynamically allocated NGX tables use the NGX API.
+ * OptiScaler tables use delete. Persistent tables are not freed.
+ */
+template <typename PFN_DestroyNGXParameters>
+static inline bool TryDestroyNGXParameters(NVSDK_NGX_Parameter* InParameters, PFN_DestroyNGXParameters NVFree = nullptr)
+{
+    if (InParameters == nullptr)
+        return false;
+
+    uint32_t allocType = NGX_AllocTypes::Unknown;
+    NVSDK_NGX_Result result = InParameters->Get(NGX_AllocTypes::AllocKey.data(), &allocType);
+
+    // Key not set. Either a bug, or the client application called Reset() on the table before destroying.
+    // Derived type unknown if this happens. Not safe to delete. Leaking is the best option.
+    if (result == NVSDK_NGX_Result_Fail)
+    {
+        LOG_WARN("Destroy called on NGX table with unset alloc type. Leaking.");
+        return false;
+    }
+
+    if (allocType == NGX_AllocTypes::NVDynamic)
+    {
+        if (NVFree != nullptr)
+        {
+            LOG_INFO("Calling NVFree");
+            result = NVFree(InParameters);
+            LOG_INFO("Calling NVFree result: {0:X}", (UINT) result);
+            return true;
+        }
+        else
+            return false;
+    }
+    else if (allocType == NGX_AllocTypes::InternDynamic)
+    {
+        delete static_cast<NVNGX_Parameters*>(InParameters);
+        return true;
+    }
+
+    return false;
 }

--- a/OptiScaler/NVNGX_Parameter.h
+++ b/OptiScaler/NVNGX_Parameter.h
@@ -959,7 +959,15 @@ struct NVNGX_Parameters : public NVSDK_NGX_Parameter
     void Reset() override
     {
         if (!m_values.empty())
+        {
+            // Preserve usage type if set
+            uint32_t allocType = NGX_AllocTypes::Unknown;
+            NVSDK_NGX_Result result = Get(NGX_AllocTypes::AllocKey.data(), &allocType);
             m_values.clear();
+
+            if (result != NVSDK_NGX_Result_Fail)
+                Set(NGX_AllocTypes::AllocKey.data(), allocType);
+        }
 
         LOG_DEBUG("Start");
 

--- a/OptiScaler/NVNGX_Parameter.h
+++ b/OptiScaler/NVNGX_Parameter.h
@@ -19,20 +19,20 @@
 /** @brief Indicates the lifetime management required by an NGX parameter table. */
 namespace NGX_AllocTypes
 {
-    // Key used to get/set enum from table
-    constexpr std::string_view AllocKey = "OptiScaler.ParamAllocType";
+// Key used to get/set enum from table
+constexpr std::string_view AllocKey = "OptiScaler.ParamAllocType";
 
-    constexpr uint32_t Unknown = 0;
-    // Standard behavior in modern DLSS. Created with NGX Allocate(). Freed with Destroy().
-    constexpr uint32_t NVDynamic = 1;
-    // Legacy DLSS. Lifetime managed internally by the SDK.
-    constexpr uint32_t NVPersistent = 2;
-    // OptiScaler implementation used internally with new/delete.
-    constexpr uint32_t InternDynamic = 3;
-    // OptiScaler implementation for legacy applications. Must maintain a persistent instance
-    // for the lifetime of the application.
-    constexpr uint32_t InternPersistent = 4;
-}
+constexpr uint32_t Unknown = 0;
+// Standard behavior in modern DLSS. Created with NGX Allocate(). Freed with Destroy().
+constexpr uint32_t NVDynamic = 1;
+// Legacy DLSS. Lifetime managed internally by the SDK.
+constexpr uint32_t NVPersistent = 2;
+// OptiScaler implementation used internally with new/delete.
+constexpr uint32_t InternDynamic = 3;
+// OptiScaler implementation for legacy applications. Must maintain a persistent instance
+// for the lifetime of the application.
+constexpr uint32_t InternPersistent = 4;
+} // namespace NGX_AllocTypes
 
 /// @brief Calculates the resolution scaling ratio override based on the provided quality level and current
 /// configuration.
@@ -686,15 +686,13 @@ struct NVNGX_Parameters : public NVSDK_NGX_Parameter
 {
     std::string Name;
 
-    NVNGX_Parameters(std::string_view name, bool isPersistent) :
-        Name(name)
-    { 
+    NVNGX_Parameters(std::string_view name, bool isPersistent) : Name(name)
+    {
         // Old flag used to indicate custom table. Obsolete?
         Set("OptiScaler", 1);
         // New tracking flag
-        Set(NGX_AllocTypes::AllocKey.data(), isPersistent ? 
-            NGX_AllocTypes::InternPersistent : 
-            NGX_AllocTypes::InternDynamic);
+        Set(NGX_AllocTypes::AllocKey.data(),
+            isPersistent ? NGX_AllocTypes::InternPersistent : NGX_AllocTypes::InternDynamic);
     }
 
 #ifdef ENABLE_ENCAPSULATED_PARAMS
@@ -1020,7 +1018,7 @@ inline static NVNGX_Parameters* GetNGXParameters(std::string_view name, bool isP
 }
 
 /**
- * @brief Sets a custom tracking tag to indicate the memory management strategy required by 
+ * @brief Sets a custom tracking tag to indicate the memory management strategy required by
  * the table, indicated by NGX_AllocTypes.
  */
 inline static void SetNGXParamAllocType(NVSDK_NGX_Parameter& params, uint32_t allocType)

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -327,6 +327,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="inputs\FSR2_Dx11.h" />
     <ClInclude Include="inputs\FSR2_Vk.h" />
     <ClInclude Include="inputs\XeSS_Dx11.h" />
+    <ClInclude Include="MathUtils.h" />
     <ClInclude Include="OptiTexts.h" />
     <ClInclude Include="shaders\depth_invert\DI_Common.h" />
     <ClInclude Include="shaders\depth_invert\DI_Dx12.h" />

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -327,6 +327,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="inputs\FSR2_Dx11.h" />
     <ClInclude Include="inputs\FSR2_Vk.h" />
     <ClInclude Include="inputs\XeSS_Dx11.h" />
+    <ClInclude Include="OptiTexts.h" />
     <ClInclude Include="shaders\depth_invert\DI_Common.h" />
     <ClInclude Include="shaders\depth_invert\DI_Dx12.h" />
     <ClInclude Include="shaders\depth_invert\precompiled\DI_Shader.h" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -695,7 +695,7 @@
     <ClInclude Include="shaders\hud_copy\HudCopy_Dx12.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="shaders\hud_copy\precompile\HudCopy_Shader.h">
+    <ClInclude Include="MathUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="shaders\output_scaling\precompile\bcds_bicubic_Shader_Vk.h">

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -728,6 +728,9 @@
     <ClInclude Include="shaders\render_ui\RUI_Dx12.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="OptiTexts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="shaders\output_scaling\precompile\bcds_kaiser2_Shader.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/OptiScaler/OptiTexts.h
+++ b/OptiScaler/OptiTexts.h
@@ -1,0 +1,52 @@
+#pragma once
+
+/**
+ * @brief Common strings and identifiers used internally by OptiScaler
+ */
+namespace OptiKeys
+{
+using CString = const char[];
+
+// Application name provided to upscalers
+inline constexpr CString ProjectID = "OptiScaler";
+
+// ID code used for the Vulkan input provider
+inline constexpr CString VkProvider = "OptiVk";
+// ID code used for the DX11 input provider
+inline constexpr CString Dx11Provider = "OptiDx11";
+// ID code used for the DX12 input provider
+inline constexpr CString Dx12Provider = "OptiDx12";
+
+// ID code used for the XeSS upscaler backend
+inline constexpr CString XeSS = "xess";
+// ID code used for the XeSS upscaler backend used with the DirectX 11 on 12 compatibility layer
+inline constexpr CString XeSS_11on12 = "xess_12";
+// ID code used for the FSR 2.1.x upscaler backend
+inline constexpr CString FSR21 = "fsr21";
+// ID code used for the FSR 2.1.x upscaler backend used with the DirectX 11 on 12 compatibility layer
+inline constexpr CString FSR21_11on12 = "fsr21_12";
+// ID code used for the FSR 2.2.x upscaler backend
+inline constexpr CString FSR22 = "fsr22";
+// ID code used for the FSR 2.2.x upscaler backend used with the DirectX 11 on 12 compatibility layer
+inline constexpr CString FSR22_11on12 = "fsr22_12";
+// ID code used for the FSR 3.1+ upscaler backend
+inline constexpr CString FSR31 = "fsr31";
+// ID code used for the FSR 3.1+ upscaler backend used with the DirectX 11 on 12 compatibility layer
+inline constexpr CString FSR31_11on12 = "fsr31_12";
+// ID code used for the DLSS upscaler backend
+inline constexpr CString DLSS = "dlss";
+// ID code used for the DLSS-D/Ray Reconstruction upscaler+denoiser backend
+inline constexpr CString DLSSD = "dlssd";
+
+inline constexpr CString FSR_UpscaleWidth = "FSR.upscaleSize.width";
+inline constexpr CString FSR_UpscaleHeight = "FSR.upscaleSize.height";
+
+inline constexpr CString FSR_NearPlane = "FSR.cameraNear";
+inline constexpr CString FSR_FarPlane = "FSR.cameraFar";
+inline constexpr CString FSR_CameraFovVertical = "FSR.cameraFovAngleVertical";
+inline constexpr CString FSR_FrameTimeDelta = "FSR.frameTimeDelta";
+inline constexpr CString FSR_ViewSpaceToMetersFactor = "FSR.viewSpaceToMetersFactor";
+inline constexpr CString FSR_TransparencyAndComp = "FSR.transparencyAndComposition";
+inline constexpr CString FSR_Reactive = "FSR.reactive";
+
+} // namespace OptiKeys

--- a/OptiScaler/SysUtils.h
+++ b/OptiScaler/SysUtils.h
@@ -183,3 +183,5 @@ inline static void to_lower_in_place(std::string& string)
 {
     std::transform(string.begin(), string.end(), string.begin(), ::tolower);
 }
+
+#include "OptiTexts.h"

--- a/OptiScaler/inputs/FG/FSR3_Dx12_FG.cpp
+++ b/OptiScaler/inputs/FG/FSR3_Dx12_FG.cpp
@@ -3,6 +3,7 @@
 
 #include "Config.h"
 #include "Util.h"
+#include "MathUtils.h"
 
 #include "resource.h"
 #include "NVNGX_Parameter.h"
@@ -23,6 +24,7 @@
 #include "fsr3/ffx_frameinterpolation.h"
 
 const UINT fgContext = 0x1337;
+using namespace OptiMath;
 
 // Swapchain create
 typedef FFX_API
@@ -1250,21 +1252,26 @@ void FSR3FG::SetUpscalerInputs(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_P
 
     float tempCameraNear = 0.0f;
     float tempCameraFar = 0.0f;
-    InParameters->Get("FSR.cameraNear", &tempCameraNear);
-    InParameters->Get("FSR.cameraFar", &tempCameraFar);
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
+
+    ngxParams.Get(OptiKeys::FSR_NearPlane, &tempCameraNear);
+    ngxParams.Get(OptiKeys::FSR_FarPlane, &tempCameraFar);
+
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
         (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
     {
         if (feature->DepthInverted())
         {
-            cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-            cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            cameraFar = cfg.FsrCameraNear.value_or_default();
+            cameraNear = cfg.FsrCameraFar.value_or_default();
         }
         else
         {
-            cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-            cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+            cameraFar = cfg.FsrCameraFar.value_or_default();
+            cameraNear = cfg.FsrCameraNear.value_or_default();
         }
     }
     else
@@ -1273,20 +1280,22 @@ void FSR3FG::SetUpscalerInputs(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_P
         cameraFar = tempCameraFar;
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFovAngleVertical", &cameraVFov) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_CameraFovVertical, &cameraVFov) != NVSDK_NGX_Result_Success)
     {
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            cameraVFov = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            cameraVFov = 2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                                     (float) feature->TargetHeight() * (float) feature->TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            cameraVFov = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            cameraVFov = GetVerticalFovFromHorizontal(hFovRad, (float) feature->TargetWidth(), (float) feature->TargetHeight());
+        }
         else
-            cameraVFov = 1.0471975511966f;
+            cameraVFov = GetRadiansFromDeg(60);
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default())
-        InParameters->Get("FSR.viewSpaceToMetersFactor", &meterFactor);
+    if (!cfg.FsrUseFsrInputValues.value_or_default())
+        ngxParams.Get(OptiKeys::FSR_ViewSpaceToMetersFactor, &meterFactor);
 
     State::Instance().lastFsrCameraFar = cameraFar;
     State::Instance().lastFsrCameraNear = cameraNear;

--- a/OptiScaler/inputs/FG/FSR3_Dx12_FG.cpp
+++ b/OptiScaler/inputs/FG/FSR3_Dx12_FG.cpp
@@ -1260,8 +1260,7 @@ void FSR3FG::SetUpscalerInputs(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_P
     ngxParams.Get(OptiKeys::FSR_NearPlane, &tempCameraNear);
     ngxParams.Get(OptiKeys::FSR_FarPlane, &tempCameraFar);
 
-    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
-        (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
+    if (!cfg.FsrUseFsrInputValues.value_or_default() || (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
     {
         if (feature->DepthInverted())
         {
@@ -1288,7 +1287,8 @@ void FSR3FG::SetUpscalerInputs(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_P
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            cameraVFov = GetVerticalFovFromHorizontal(hFovRad, (float) feature->TargetWidth(), (float) feature->TargetHeight());
+            cameraVFov =
+                GetVerticalFovFromHorizontal(hFovRad, (float) feature->TargetWidth(), (float) feature->TargetHeight());
         }
         else
             cameraVFov = GetRadiansFromDeg(60);

--- a/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
+++ b/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
@@ -2,9 +2,10 @@
 #include "Upscaler_Inputs_Dx12.h"
 #include <hudfix/Hudfix_Dx12.h>
 #include <resource_tracking/ResTrack_dx12.h>
-
 #include "shaders/depth_scale/DS_Dx12.h"
+#include "MathUtils.h"
 
+using namespace OptiMath;
 static DS_Dx12* DepthScale = nullptr;
 
 void UpscalerInputsDx12::Init(ID3D12Device* device)
@@ -42,21 +43,26 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
 
     float tempCameraNear = 0.0f;
     float tempCameraFar = 0.0f;
-    InParameters->Get("FSR.cameraNear", &tempCameraNear);
-    InParameters->Get("FSR.cameraFar", &tempCameraFar);
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
+
+    ngxParams.Get(OptiKeys::FSR_NearPlane, &tempCameraNear);
+    ngxParams.Get(OptiKeys::FSR_FarPlane, &tempCameraFar);
+
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
         (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
     {
         if (feature->DepthInverted())
         {
-            cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-            cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            cameraFar = cfg.FsrCameraNear.value_or_default();
+            cameraNear = cfg.FsrCameraFar.value_or_default();
         }
         else
         {
-            cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-            cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+            cameraFar = cfg.FsrCameraFar.value_or_default();
+            cameraNear = cfg.FsrCameraNear.value_or_default();
         }
     }
     else
@@ -65,20 +71,22 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
         cameraFar = tempCameraFar;
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFovAngleVertical", &cameraVFov) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_CameraFovVertical, &cameraVFov) != NVSDK_NGX_Result_Success)
     {
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            cameraVFov = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            cameraVFov = 2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                                     (float) feature->TargetHeight() * (float) feature->TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            cameraVFov = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            cameraVFov = GetVerticalFovFromHorizontal(hFovRad, (float)feature->TargetWidth(), (float) feature->TargetHeight());
+        }
         else
-            cameraVFov = 1.0471975511966f;
+            cameraVFov = GetRadiansFromDeg(60);
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default())
-        InParameters->Get("FSR.viewSpaceToMetersFactor", &meterFactor);
+    if (!cfg.FsrUseFsrInputValues.value_or_default())
+        ngxParams.Get(OptiKeys::FSR_ViewSpaceToMetersFactor, &meterFactor);
 
     State::Instance().lastFsrCameraFar = cameraFar;
     State::Instance().lastFsrCameraNear = cameraNear;

--- a/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
+++ b/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
@@ -51,8 +51,7 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
     ngxParams.Get(OptiKeys::FSR_NearPlane, &tempCameraNear);
     ngxParams.Get(OptiKeys::FSR_FarPlane, &tempCameraFar);
 
-    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
-        (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
+    if (!cfg.FsrUseFsrInputValues.value_or_default() || (tempCameraNear == 0.0f && tempCameraFar == 0.0f))
     {
         if (feature->DepthInverted())
         {
@@ -79,7 +78,8 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            cameraVFov = GetVerticalFovFromHorizontal(hFovRad, (float)feature->TargetWidth(), (float) feature->TargetHeight());
+            cameraVFov =
+                GetVerticalFovFromHorizontal(hFovRad, (float) feature->TargetWidth(), (float) feature->TargetHeight());
         }
         else
             cameraVFov = GetRadiansFromDeg(60);

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
@@ -253,6 +253,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_Shutdown1(ID3D11Device* InDevice)
 
 #pragma region NVSDK_NGX_D3D11 Parameters
 
+/**
+ * @brief [Deprecated NGX API] Superceeded by NVSDK_NGX_AllocateParameters and NVSDK_NGX_GetCapabilityParameters.
+ *
+ * Retrieves a common NVSDK parameter map for providing params to the SDK. The lifetime of this
+ * map is NOT managed by the application. It is expected to be managed internally by the SDK.
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -272,14 +278,24 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_GetParameters(NVSDK_NGX_Parameter
         if (result == NVSDK_NGX_Result_Success)
         {
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVPersistent);
             return result;
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiDx11");
+    // Get custom parameters if using custom backend
+    static NVNGX_Parameters oldParams = NVNGX_Parameters("OptiDx11", true);
+    *OutParameters = &oldParams;
+    InitNGXParameters(*OutParameters);
+
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Allocates a new NVSDK parameter map pre-populated with NGX capabilities and information about available
+ * features. The output parameter map may also be used in the same ways as a parameter map allocated with
+ * AllocateParameters(). The lifetime of this map is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -299,15 +315,21 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_GetCapabilityParameters(NVSDK_NGX
         if (result == NVSDK_NGX_Result_Success)
         {
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return result;
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiDx11");
+    *OutParameters = new NVNGX_Parameters("OptiDx11", false);
+    InitNGXParameters(*OutParameters);
 
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Allocates a new parameter map used to provide parameters needed by the DLSS API. The lifetime of this map
+ * is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_AllocateParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -322,12 +344,14 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_AllocateParameters(NVSDK_NGX_Para
         LOG_INFO("calling NVNGXProxy::D3D11_AllocateParameters result: {0:X}", (UINT) result);
 
         if (result == NVSDK_NGX_Result_Success)
+        {
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return result;
+        }
     }
 
-    auto params = new NVNGX_Parameters();
-    params->Name = "OptiDx11";
-    *OutParameters = params;
+    *OutParameters = new NVNGX_Parameters("OptiDx11", false);
+    InitNGXParameters(*OutParameters);
 
     return NVSDK_NGX_Result_Success;
 }
@@ -351,19 +375,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_DestroyParameters(NVSDK_NGX_Param
     if (InParameters == nullptr)
         return NVSDK_NGX_Result_Fail;
 
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::D3D11_DestroyParameters() != nullptr)
-    {
-        LOG_INFO("calling NVNGXProxy::D3D11_DestroyParameters");
-        auto result = NVNGXProxy::D3D11_DestroyParameters()(InParameters);
-        LOG_INFO("calling NVNGXProxy::D3D11_DestroyParameters result: {0:X}", (UINT) result);
+    const bool success = TryDestroyNGXParameters(InParameters, NVNGXProxy::D3D11_DestroyParameters());
 
-        return result;
-    }
-
-    delete InParameters;
-
-    return NVSDK_NGX_Result_Success;
+    return success ? NVSDK_NGX_Result_Success : NVSDK_NGX_Result_Fail;
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId,

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
@@ -351,7 +351,6 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_AllocateParameters(NVSDK_NGX_Para
     }
 
     *OutParameters = new NVNGX_Parameters("OptiDx11", false);
-    InitNGXParameters(*OutParameters);
 
     return NVSDK_NGX_Result_Success;
 }

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -44,6 +44,11 @@ public:
     ~ScopedInit() { _skipInit = previousState; }
 };
 
+static bool GetIsDlssModuleInited()
+{
+    return Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::IsDx12Inited();
+}
+
 #pragma region DLSS Init Calls
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
@@ -120,7 +125,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
     State::Instance().currentD3D12Device = InDevice;
     D3D12Hooks::HookDevice(InDevice);
 
-    if (!State::Instance().isWorkingAsNvngx)
+    if (State::Instance().workingMode != WorkingMode::Nvngx)
     {
         UpscalerTimeDx12::Init(InDevice);
     }
@@ -361,8 +366,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
     // If DLSS is enabled and the real DLSS module is loaded, get native NGX table
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::D3D12_GetParameters() != nullptr)
+    if (GetIsDlssModuleInited() && NVNGXProxy::D3D12_GetParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters");
         auto result = NVNGXProxy::D3D12_GetParameters()(OutParameters);
@@ -373,14 +377,15 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
         if (result == NVSDK_NGX_Result_Success)
         {
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVPersistent);
             return NVSDK_NGX_Result_Success;
         }
     }
 
     // Get custom parameters if using custom backend
-    static NVNGX_Parameters oldParams = NVNGX_Parameters();
-    GetNGXParameters("OptiDx12", oldParams);
+    static NVNGX_Parameters oldParams = NVNGX_Parameters("OptiDx12", true);
     *OutParameters = &oldParams;
+    InitNGXParameters(*OutParameters);
 
     return NVSDK_NGX_Result_Success;
 }
@@ -398,8 +403,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
     // Get native DLSS params if DLSS is enabled and the module is loaded
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::IsDx12Inited() && NVNGXProxy::D3D12_GetCapabilityParameters() != nullptr)
+    if (GetIsDlssModuleInited() && NVNGXProxy::IsDx12Inited() && NVNGXProxy::D3D12_GetCapabilityParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters");
         auto result = NVNGXProxy::D3D12_GetCapabilityParameters()(OutParameters);
@@ -408,14 +412,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX
 
         if (result == NVSDK_NGX_Result_Success)
         {
+            // Init external NGX table with current configuration and mark as dynamic+external
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return NVSDK_NGX_Result_Success;
         }
     }
 
     // Get custom parameters if using custom backend
-    auto& params = *(new NVNGX_Parameters());
-    GetNGXParameters("OptiDx12", params);
+    auto& params = *(new NVNGX_Parameters("OptiDx12", false));
+    InitNGXParameters(&params);
     *OutParameters = &params;
 
     return NVSDK_NGX_Result_Success;
@@ -429,8 +435,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Para
 {
     LOG_FUNC();
 
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::D3D12_AllocateParameters() != nullptr)
+    if (GetIsDlssModuleInited() && NVNGXProxy::D3D12_AllocateParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters");
         auto result = NVNGXProxy::D3D12_AllocateParameters()(OutParameters);
@@ -438,11 +443,13 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Para
             (UINT64)*OutParameters);
 
         if (result == NVSDK_NGX_Result_Success)
+        {
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return result;
+        }
     }
 
-    auto* params = new NVNGX_Parameters();
-    params->Name = "OptiDx12";
+    auto* params = new NVNGX_Parameters("OptiDx12", false);
     *OutParameters = params;
 
     return NVSDK_NGX_Result_Success;
@@ -464,8 +471,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_PopulateParameters_Impl(NVSDK_NGX
 }
 
 /**
- * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters.
- Must not be called on maps returned by GetParameters().
+ * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters. 
+ Must not be called on maps returned by GetParameters(). Unsupported tables will not be freed.
  */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
 {
@@ -474,28 +481,22 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Param
     if (InParameters == nullptr)
         return NVSDK_NGX_Result_Fail;
 
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::D3D12_DestroyParameters() != nullptr)
-    {
-        LOG_INFO("Calling NVNGXProxy::D3D12_DestroyParameters");
-        auto result = NVNGXProxy::D3D12_DestroyParameters()(InParameters);
-        LOG_INFO("Calling NVNGXProxy::D3D12_DestroyParameters result: {0:X}", (UINT)result);
+    const bool isUsingDlss = Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule();
+    const bool success = TryDestroyNGXParameters(InParameters, NVNGXProxy::D3D12_DestroyParameters());
+
+    if (isUsingDlss)
         UpscalerInputsDx12::Reset();
 
-        return NVSDK_NGX_Result_Success;
-    }
-
-    delete InParameters;
-    return NVSDK_NGX_Result_Success;
+    return success ? NVSDK_NGX_Result_Success : NVSDK_NGX_Result_Fail;
 }
 
 #pragma endregion
 
 #pragma region DLSS Feature Calls
 
-static std::string GetUpscalerBackend()
+static std::string_view GetUpscalerBackend()
 {
-    std::string name = "xess"; // Default
+    std::string_view name = "xess"; // Default
 
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::IsDx12Inited())
         name = "dlss";
@@ -561,7 +562,8 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
     Dx12Contexts[handleId] = {};
 
     // Retrieve feature implementation
-    if (!FeatureProvider_Dx12::GetFeature(featureName, handleId, InParameters, &Dx12Contexts[handleId].feature))
+    if (!FeatureProvider_Dx12::GetFeature(featureName, handleId, 
+            InParameters, &Dx12Contexts[handleId].feature))
     {
         LOG_ERROR("Failed to retrieve feature implementation for '{}'", featureName);
 
@@ -586,7 +588,7 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
         if (shouldRestore)
             D3D12Hooks::SetRootSignatureTracking(true);
 
-        // Partial cleanup – handle is allocated but context is incomplete
+        // Partial cleanup â€“ handle is allocated but context is incomplete
         Dx12Contexts.erase(handleId);
         return NVSDK_NGX_Result_Fail;
     }
@@ -836,6 +838,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     const uint32_t handleId = InFeatureHandle->Id;
 
     auto ctxIt = Dx12Contexts.find(handleId);
+
     if (ctxIt == Dx12Contexts.end())
     {
         LOG_WARN("No context found for handle {}", handleId);
@@ -845,17 +848,10 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     ContextData<IFeature_Dx12>& ctxData = ctxIt->second;
     IFeature_Dx12* feature = ctxData.feature.get();
 
-    if (!feature)
-    {
-        LOG_WARN("Feature pointer is null for handle {}", handleId);
-        return NVSDK_NGX_Result_FAIL_FeatureNotFound;
-    }
+    if (feature == nullptr) // Prevent source api name flicker when dlssg is active
+        state.setInputApiName = state.currentInputApiName;
 
-    // Prevent API name flicker (e.g., during backend transitions or DLSSG)
-    if (state.setInputApiName == state.currentInputApiName)
-        state.setInputApiName.clear();
-
-    const std::string_view targetApiName = state.setInputApiName.empty() ? "DLSS" : state.setInputApiName;
+    const std::string_view targetApiName = state.setInputApiName.empty() ? "DLSS" : state.setInputApiName.c_str();
 
     if (state.currentInputApiName != targetApiName)
         state.currentInputApiName = targetApiName;
@@ -871,26 +867,24 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
         LOG_INFO("Progress callback provided but unused in synchronous OptiScaler path");
 
     // Resolution change detection (only for upscalers that may require recreation)
-    const bool isFSR31OrLater = feature->Name().starts_with("FSR") && feature->Version() >= feature_version{ 3, 1, 0 };
+    if (feature != nullptr)
+    {
+        const bool isFSR31OrLater = feature->Name().starts_with("FSR") && feature->Version() >= feature_version { 3, 1, 0 };
 
-    if (!isFSR31OrLater && feature->UpdateOutputResolution(InParameters))
-        state.changeBackend[handleId] = true;
+        // FSR 3.1 supports upscaleSize that doesn't need reinit to change output resolution
+        if (!isFSR31OrLater && feature->UpdateOutputResolution(InParameters))
+            state.changeBackend[handleId] = true;
+    }
 
     // Backend change or recreation requested
-    if (state.changeBackend.contains(handleId) && state.changeBackend[handleId])
+    if (state.changeBackend[handleId])
     {
-        LOG_INFO("Performing backend change/recreation for handle {} to '{}'", handleId, state.newBackend);
-
         UpscalerInputsDx12::Reset();
         D3D12Hooks::SetRootSignatureTracking(true);
 
-        FeatureProvider_Dx12::ChangeFeature(state.newBackend, D3D12Device, InCmdList, handleId, InParameters, &ctxData);
+        FeatureProvider_Dx12::ChangeFeature(state.newBackend, D3D12Device, 
+            InCmdList, handleId, InParameters, &ctxData);
         feature = ctxData.feature.get();
-
-        state.changeBackend.erase(handleId);
-
-        if (!state.newBackend.empty())
-            state.newBackend.clear();
 
         evalCounter = 0;
         return NVSDK_NGX_Result_Success;
@@ -906,7 +900,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     }
 
     state.currentFeature = feature;
-
+    
     // Root signature restoration setup
     const bool restoreCompute = cfg.RestoreComputeSignature.value_or_default();
     const bool restoreGraphic = cfg.RestoreGraphicSignature.value_or_default();
@@ -919,7 +913,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     UpscalerInputsDx12::UpscaleStart(InCmdList, InParameters, feature);
     FSR3FG::SetUpscalerInputs(InCmdList, InParameters, feature);
 
-    if (!state.isWorkingAsNvngx)
+    if (State::Instance().workingMode != WorkingMode::Nvngx)
         UpscalerTimeDx12::UpscaleStart(InCmdList);
 
     // Evaluate the feature
@@ -932,7 +926,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     // Cleanup on success
     if (evalSuccess)
     {
-        if (!state.isWorkingAsNvngx)
+        if (State::Instance().workingMode != WorkingMode::Nvngx)
             UpscalerTimeDx12::UpscaleEnd(InCmdList);
 
         UpscalerInputsDx12::UpscaleEnd(InCmdList, InParameters, feature);

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -471,7 +471,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_PopulateParameters_Impl(NVSDK_NGX
 }
 
 /**
- * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters. 
+ * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters.
  Must not be called on maps returned by GetParameters(). Unsupported tables will not be freed.
  */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
@@ -562,8 +562,7 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
     Dx12Contexts[handleId] = {};
 
     // Retrieve feature implementation
-    if (!FeatureProvider_Dx12::GetFeature(featureName, handleId, 
-            InParameters, &Dx12Contexts[handleId].feature))
+    if (!FeatureProvider_Dx12::GetFeature(featureName, handleId, InParameters, &Dx12Contexts[handleId].feature))
     {
         LOG_ERROR("Failed to retrieve feature implementation for '{}'", featureName);
 
@@ -633,11 +632,10 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
  * provides a handle used to reference the feature elsewhere in the API. Currently supports
  * various TSR and Frame Generation algorithms, including a special case for DLSS-RR passthrough.
  */
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(
-    ID3D12GraphicsCommandList* InCmdList,
-    NVSDK_NGX_Feature InFeatureID,
-    NVSDK_NGX_Parameter* InParameters,
-    NVSDK_NGX_Handle** OutHandle)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsCommandList* InCmdList,
+                                                             NVSDK_NGX_Feature InFeatureID,
+                                                             NVSDK_NGX_Parameter* InParameters,
+                                                             NVSDK_NGX_Handle** OutHandle)
 {
     LOG_FUNC();
 
@@ -827,11 +825,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetFeatureRequirements(
     return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
 }
 
-static NVSDK_NGX_Result TryEvaluateOptiFeature(
-    ID3D12GraphicsCommandList* InCmdList,
-    const NVSDK_NGX_Handle* InFeatureHandle,
-    NVSDK_NGX_Parameter* InParameters,
-    PFN_NVSDK_NGX_ProgressCallback InCallback)
+static NVSDK_NGX_Result TryEvaluateOptiFeature(ID3D12GraphicsCommandList* InCmdList,
+                                               const NVSDK_NGX_Handle* InFeatureHandle,
+                                               NVSDK_NGX_Parameter* InParameters,
+                                               PFN_NVSDK_NGX_ProgressCallback InCallback)
 {
     State& state = State::Instance();
     const Config& cfg = *Config::Instance();
@@ -869,7 +866,8 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     // Resolution change detection (only for upscalers that may require recreation)
     if (feature != nullptr)
     {
-        const bool isFSR31OrLater = feature->Name().starts_with("FSR") && feature->Version() >= feature_version { 3, 1, 0 };
+        const bool isFSR31OrLater =
+            feature->Name().starts_with("FSR") && feature->Version() >= feature_version { 3, 1, 0 };
 
         // FSR 3.1 supports upscaleSize that doesn't need reinit to change output resolution
         if (!isFSR31OrLater && feature->UpdateOutputResolution(InParameters))
@@ -882,8 +880,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
         UpscalerInputsDx12::Reset();
         D3D12Hooks::SetRootSignatureTracking(true);
 
-        FeatureProvider_Dx12::ChangeFeature(state.newBackend, D3D12Device, 
-            InCmdList, handleId, InParameters, &ctxData);
+        FeatureProvider_Dx12::ChangeFeature(state.newBackend, D3D12Device, InCmdList, handleId, InParameters, &ctxData);
         feature = ctxData.feature.get();
 
         evalCounter = 0;
@@ -900,7 +897,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
     }
 
     state.currentFeature = feature;
-    
+
     // Root signature restoration setup
     const bool restoreCompute = cfg.RestoreComputeSignature.value_or_default();
     const bool restoreGraphic = cfg.RestoreGraphicSignature.value_or_default();
@@ -955,11 +952,10 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(
  * @brief Per-frame feature execution. Runs a feature (upscaler, framegen, etc.) on a given command list using a
  * preexisting feature instance referenced by a unique handle.
  */
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(
-    ID3D12GraphicsCommandList* InCmdList,
-    const NVSDK_NGX_Handle* InFeatureHandle,
-    NVSDK_NGX_Parameter* InParameters,
-    PFN_NVSDK_NGX_ProgressCallback InCallback)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCommandList* InCmdList,
+                                                               const NVSDK_NGX_Handle* InFeatureHandle,
+                                                               NVSDK_NGX_Parameter* InParameters,
+                                                               PFN_NVSDK_NGX_ProgressCallback InCallback)
 {
     if (!InFeatureHandle)
     {
@@ -1010,10 +1006,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(
 
 #pragma region DLSS Buffer Size Call
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(
-    NVSDK_NGX_Feature InFeatureId,
-    const NVSDK_NGX_Parameter* InParameters,
-    size_t* OutSizeInBytes)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId,
+                                                                    const NVSDK_NGX_Parameter* InParameters,
+                                                                    size_t* OutSizeInBytes)
 {
     if (OutSizeInBytes == nullptr)
         return NVSDK_NGX_Result_FAIL_InvalidParameter;

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -32,10 +32,10 @@ static inline bool _skipInit = false;
 
 class ScopedInit
 {
-  private:
+private:
     bool previousState;
 
-  public:
+public:
     ScopedInit()
     {
         previousState = _skipInit;
@@ -46,10 +46,12 @@ class ScopedInit
 
 #pragma region DLSS Init Calls
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApplicationId,
-                                                        const wchar_t* InApplicationDataPath, ID3D12Device* InDevice,
-                                                        NVSDK_NGX_Version InSDKVersion,
-                                                        const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
+    unsigned long long InApplicationId,
+    const wchar_t* InApplicationDataPath,
+    ID3D12Device* InDevice,
+    NVSDK_NGX_Version InSDKVersion,
+    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
 {
     LOG_FUNC();
 
@@ -73,8 +75,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApp
         {
             LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext");
             auto result = NVNGXProxy::D3D12_Init_Ext()(InApplicationId, InApplicationDataPath, InDevice, InSDKVersion,
-                                                       InFeatureInfo);
-            LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext result: {0:X}", (UINT) result);
+                InFeatureInfo);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext result: {0:X}", (UINT)result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -98,7 +100,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApp
     }
 
     LOG_INFO("AppId: {0}", InApplicationId);
-    LOG_INFO("SDK: {0:x}", (unsigned int) InSDKVersion);
+    LOG_INFO("SDK: {0:x}", (unsigned int)InSDKVersion);
     appDataPath = std::wstring(InApplicationDataPath);
 
     LOG_INFO("InApplicationDataPath {0}", wstring_to_string(appDataPath));
@@ -118,7 +120,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApp
     State::Instance().currentD3D12Device = InDevice;
     D3D12Hooks::HookDevice(InDevice);
 
-    if (State::Instance().workingMode != WorkingMode::Nvngx)
+    if (!State::Instance().isWorkingAsNvngx)
     {
         UpscalerTimeDx12::Init(InDevice);
     }
@@ -130,10 +132,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApp
     return NVSDK_NGX_Result_Success;
 }
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(unsigned long long InApplicationId,
-                                                    const wchar_t* InApplicationDataPath, ID3D12Device* InDevice,
-                                                    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo,
-                                                    NVSDK_NGX_Version InSDKVersion)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(
+    unsigned long long InApplicationId,
+    const wchar_t* InApplicationDataPath,
+    ID3D12Device* InDevice,
+    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo,
+    NVSDK_NGX_Version InSDKVersion)
 {
     LOG_FUNC();
 
@@ -152,7 +156,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(unsigned long long InApplica
             auto result =
                 NVNGXProxy::D3D12_Init()(InApplicationId, InApplicationDataPath, InDevice, InFeatureInfo, InSDKVersion);
 
-            LOG_INFO("calling NVNGXProxy::D3D12_Init result: {0:X}", (UINT) result);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init result: {0:X}", (UINT)result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -171,19 +175,22 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(unsigned long long InApplica
     //     DLSSGMod::D3D12_Init(InApplicationId, InApplicationDataPath, InDevice, InFeatureInfo, InSDKVersion);
     // }
 
-    ScopedInit scopedInit {};
+    ScopedInit scopedInit{};
     auto result =
         NVSDK_NGX_D3D12_Init_Ext(InApplicationId, InApplicationDataPath, InDevice, InSDKVersion, InFeatureInfo);
+
     LOG_DEBUG("was called NVSDK_NGX_D3D12_Init_Ext");
     return result;
 }
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProjectId,
-                                                              NVSDK_NGX_EngineType InEngineType,
-                                                              const char* InEngineVersion,
-                                                              const wchar_t* InApplicationDataPath,
-                                                              ID3D12Device* InDevice, NVSDK_NGX_Version InSDKVersion,
-                                                              const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(
+    const char* InProjectId,
+    NVSDK_NGX_EngineType InEngineType,
+    const char* InEngineVersion,
+    const wchar_t* InApplicationDataPath,
+    ID3D12Device* InDevice,
+    NVSDK_NGX_Version InSDKVersion,
+    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
 {
     LOG_FUNC();
 
@@ -201,9 +208,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProj
 
             auto result =
                 NVNGXProxy::D3D12_Init_ProjectID()(InProjectId, InEngineType, InEngineVersion, InApplicationDataPath,
-                                                   InDevice, InSDKVersion, InFeatureInfo);
+                    InDevice, InSDKVersion, InFeatureInfo);
 
-            LOG_INFO("calling NVNGXProxy::D3D12_Init_ProjectID result: {0:X}", (UINT) result);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init_ProjectID result: {0:X}", (UINT)result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -211,7 +218,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProj
     }
 
     LOG_INFO("InProjectId: {0}", InProjectId);
-    LOG_INFO("InEngineType: {0}", (int) InEngineType);
+    LOG_INFO("InEngineType: {0}", (int)InEngineType);
     LOG_INFO("InEngineVersion: {0}", InEngineVersion);
 
     State::Instance().NVNGX_ProjectId = std::string(InProjectId);
@@ -224,7 +231,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProj
         return NVSDK_NGX_Result_Success;
     }
 
-    ScopedInit scopedInit {};
+    ScopedInit scopedInit{};
     auto result = NVSDK_NGX_D3D12_Init_Ext(0x1337, InApplicationDataPath, InDevice, InSDKVersion, InFeatureInfo);
     return result;
 }
@@ -238,7 +245,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_with_ProjectID(
     LOG_FUNC();
 
     LOG_INFO("InProjectId: {0}", InProjectId);
-    LOG_INFO("InEngineType: {0}", (int) InEngineType);
+    LOG_INFO("InEngineType: {0}", (int)InEngineType);
     LOG_INFO("InEngineVersion: {0}", InEngineVersion);
 
     State::Instance().NVNGX_ProjectId = std::string(InProjectId);
@@ -330,6 +337,22 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Shutdown1(ID3D12Device* InDevice)
 
 #pragma region DLSS Parameter Calls
 
+/**
+ * @brief Allocates and populates a preexisting NGX param map.
+ */
+static void GetNGXParameters(std::string InName, NVNGX_Parameters& params)
+{
+    params.Name = InName;
+    InitNGXParameters(&params);
+    params.Set("OptiScaler", 1);
+}
+
+/**
+ * @brief [Deprecated NGX API] Superceeded by NVSDK_NGX_AllocateParameters and NVSDK_NGX_GetCapabilityParameters.
+ *
+ * Retrieves a common NVSDK parameter map for providing params to the SDK. The lifetime of this
+ * map is NOT managed by the application. It is expected to be managed internally by the SDK.
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -337,14 +360,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
     if (OutParameters == nullptr)
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
+    // If DLSS is enabled and the real DLSS module is loaded, get native NGX table
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
         NVNGXProxy::D3D12_GetParameters() != nullptr)
     {
-        LOG_INFO("calling NVNGXProxy::D3D12_GetParameters");
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters");
         auto result = NVNGXProxy::D3D12_GetParameters()(OutParameters);
-        LOG_INFO("calling NVNGXProxy::D3D12_GetParameters result: {0:X}, ptr: {1:X}", (UINT) result,
-                 (UINT64) *OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters result: {0:X}, ptr: {1:X}", (UINT)result,
+            (UINT64)*OutParameters);
 
+        // Copy OptiScaler config to real NGX param table
         if (result == NVSDK_NGX_Result_Success)
         {
             InitNGXParameters(*OutParameters);
@@ -352,11 +377,19 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiDx12");
+    // Get custom parameters if using custom backend
+    static NVNGX_Parameters oldParams = NVNGX_Parameters();
+    GetNGXParameters("OptiDx12", oldParams);
+    *OutParameters = &oldParams;
 
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Allocates a new NVSDK parameter map pre-populated with NGX capabilities and information about available features.
+ * The output parameter map may also be used in the same ways as a parameter map allocated with AllocateParameters().
+ * The lifetime of this map is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -364,13 +397,14 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX
     if (OutParameters == nullptr)
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
+    // Get native DLSS params if DLSS is enabled and the module is loaded
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
         NVNGXProxy::IsDx12Inited() && NVNGXProxy::D3D12_GetCapabilityParameters() != nullptr)
     {
-        LOG_INFO("calling NVNGXProxy::D3D12_GetCapabilityParameters");
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters");
         auto result = NVNGXProxy::D3D12_GetCapabilityParameters()(OutParameters);
-        LOG_INFO("calling NVNGXProxy::D3D12_GetCapabilityParameters result: {0:X}, ptr: {1:X}", (UINT) result,
-                 (UINT64) *OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters result: {0:X}, ptr: {1:X}", (UINT)result,
+            (UINT64)*OutParameters);
 
         if (result == NVSDK_NGX_Result_Success)
         {
@@ -379,11 +413,18 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiDx12");
+    // Get custom parameters if using custom backend
+    auto& params = *(new NVNGX_Parameters());
+    GetNGXParameters("OptiDx12", params);
+    *OutParameters = &params;
 
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Allocates a new parameter map used to provide parameters needed by the DLSS API. The lifetime of this map
+ * is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -391,16 +432,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Para
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
         NVNGXProxy::D3D12_AllocateParameters() != nullptr)
     {
-        LOG_INFO("calling NVNGXProxy::D3D12_AllocateParameters");
+        LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters");
         auto result = NVNGXProxy::D3D12_AllocateParameters()(OutParameters);
-        LOG_INFO("calling NVNGXProxy::D3D12_AllocateParameters result: {0:X}, ptr: {1:X}", (UINT) result,
-                 (UINT64) *OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters result: {0:X}, ptr: {1:X}", (UINT)result,
+            (UINT64)*OutParameters);
 
         if (result == NVSDK_NGX_Result_Success)
             return result;
     }
 
-    auto params = new NVNGX_Parameters();
+    auto* params = new NVNGX_Parameters();
     params->Name = "OptiDx12";
     *OutParameters = params;
 
@@ -422,6 +463,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_PopulateParameters_Impl(NVSDK_NGX
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters.
+ Must not be called on maps returned by GetParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
 {
     LOG_FUNC();
@@ -432,9 +477,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Param
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
         NVNGXProxy::D3D12_DestroyParameters() != nullptr)
     {
-        LOG_INFO("calling NVNGXProxy::D3D12_DestroyParameters");
+        LOG_INFO("Calling NVNGXProxy::D3D12_DestroyParameters");
         auto result = NVNGXProxy::D3D12_DestroyParameters()(InParameters);
-        LOG_INFO("calling NVNGXProxy::D3D12_DestroyParameters result: {0:X}", (UINT) result);
+        LOG_INFO("Calling NVNGXProxy::D3D12_DestroyParameters result: {0:X}", (UINT)result);
         UpscalerInputsDx12::Reset();
 
         return NVSDK_NGX_Result_Success;
@@ -448,146 +493,205 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_DestroyParameters(NVSDK_NGX_Param
 
 #pragma region DLSS Feature Calls
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsCommandList* InCmdList,
-                                                             NVSDK_NGX_Feature InFeatureID,
-                                                             NVSDK_NGX_Parameter* InParameters,
-                                                             NVSDK_NGX_Handle** OutHandle)
+static std::string GetUpscalerBackend()
 {
-    LOG_FUNC();
+    std::string name = "xess"; // Default
 
-    if (State::Instance().activeFgInput == FGInput::Nukems && DLSSGMod::isDx12Available() &&
-        InFeatureID == NVSDK_NGX_Feature_FrameGeneration)
+    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::IsDx12Inited())
+        name = "dlss";
+
+    if (Config::Instance()->Dx12Upscaler.has_value())
+        name = Config::Instance()->Dx12Upscaler.value();
+
+    return name;
+}
+
+static bool EnsureD3D12Device(ID3D12GraphicsCommandList* cmdList)
+{
+    if (D3D12Device)
+        return true;
+
+    LOG_DEBUG("Get D3D12 device from InCmdList!");
+
+    if (FAILED(cmdList->GetDevice(IID_PPV_ARGS(&D3D12Device))) || !D3D12Device)
     {
-        auto result = DLSSGMod::D3D12_CreateFeature(InCmdList, InFeatureID, InParameters, OutHandle);
-        LOG_INFO("Creating new modded DLSSG feature with HandleId: {0}", (*OutHandle)->Id);
-        return result;
-    }
-    else if (InFeatureID != NVSDK_NGX_Feature_SuperSampling && InFeatureID != NVSDK_NGX_Feature_RayReconstruction)
-    {
-        if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::InitDx12(D3D12Device) &&
-            NVNGXProxy::D3D12_CreateFeature() != nullptr)
-        {
-            LOG_INFO("calling D3D12_CreateFeature for ({0})", (int) InFeatureID);
-            auto result = NVNGXProxy::D3D12_CreateFeature()(InCmdList, InFeatureID, InParameters, OutHandle);
-
-            if (result == NVSDK_NGX_Result_Success)
-            {
-                LOG_INFO("D3D12_CreateFeature HandleId for ({0}): {1:X}", (int) InFeatureID, (*OutHandle)->Id);
-            }
-            else
-            {
-                LOG_INFO("D3D12_CreateFeature result for ({0}): {1:X}", (int) InFeatureID, (UINT) result);
-            }
-
-            return result;
-        }
-        else
-        {
-            LOG_ERROR("Can't create this feature ({0})!", (int) InFeatureID);
-            return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
-        }
+        LOG_ERROR("Can't get Dx12Device from InCmdList!");
+        return false;
     }
 
-    // Create feature
-    State::Instance().api = DX12;
-    auto handleId = IFeature::GetNextHandleId();
-    LOG_INFO("HandleId: {0}", handleId);
+    return true;
+}
 
-    // Root signature restore
-    if (Config::Instance()->RestoreComputeSignature.value_or_default() ||
-        Config::Instance()->RestoreGraphicSignature.value_or_default())
-    {
-        D3D12Hooks::SetRootSignatureTracking(false);
-    }
+static NVSDK_NGX_Result TryCreateOptiFeature(
+    ID3D12GraphicsCommandList* InCmdList,
+    NVSDK_NGX_Feature InFeatureID,
+    NVSDK_NGX_Parameter* InParameters,
+    NVSDK_NGX_Handle** OutHandle)
+{
+    State& state = State::Instance();
+    const Config& cfg = *Config::Instance();
 
+    state.api = DX12;
+
+    const uint32_t handleId = IFeature::GetNextHandleId();
+    LOG_INFO("Creating OptiScaler feature, HandleId: {}", handleId);
+
+    // Determine backend name
+    std::string featureName;
     if (InFeatureID == NVSDK_NGX_Feature_SuperSampling)
     {
-        std::string upscalerChoice = "xess"; // Default XeSS
-
-        // If original NVNGX available use DLSS as base upscaler
-        if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::IsDx12Inited())
-            upscalerChoice = "dlss";
-
-        if (Config::Instance()->Dx12Upscaler.has_value())
-            upscalerChoice = Config::Instance()->Dx12Upscaler.value();
-
-        LOG_INFO("Creating new {} upscaler", upscalerChoice);
-
-        Dx12Contexts[handleId] = {};
-
-        if (!FeatureProvider_Dx12::GetFeature(upscalerChoice, handleId, InParameters, &Dx12Contexts[handleId].feature))
-        {
-            LOG_ERROR("Upscaler can't created");
-            return NVSDK_NGX_Result_Fail;
-        }
+        featureName = GetUpscalerBackend();
+        LOG_INFO("Creating {} upscaler feature", featureName);
     }
-    else if (InFeatureID == NVSDK_NGX_Feature_RayReconstruction)
+    else
     {
-        LOG_INFO("creating new DLSSD feature");
-
-        Dx12Contexts[handleId] = {};
-
-        if (!FeatureProvider_Dx12::GetFeature("dlssd", handleId, InParameters, &Dx12Contexts[handleId].feature))
-        {
-            LOG_ERROR("DLSSD can't created");
-            return NVSDK_NGX_Result_Fail;
-        }
+        featureName = "dlssd";
+        LOG_INFO("Creating DLSSD (Ray Reconstruction) feature");
     }
 
-    auto deviceContext = Dx12Contexts[handleId].feature.get();
+    // Root signature restoration setup
+    const bool restoreCompute = cfg.RestoreComputeSignature.value_or_default();
+    const bool restoreGraphic = cfg.RestoreGraphicSignature.value_or_default();
+    const bool shouldRestore = restoreCompute || restoreGraphic;
 
+    if (shouldRestore)
+        D3D12Hooks::SetRootSignatureTracking(false);
+
+    // Create context entry
+    Dx12Contexts[handleId] = {};
+
+    // Retrieve feature implementation
+    if (!FeatureProvider_Dx12::GetFeature(featureName, handleId, InParameters, &Dx12Contexts[handleId].feature))
+    {
+        LOG_ERROR("Failed to retrieve feature implementation for '{}'", featureName);
+
+        if (shouldRestore)
+            D3D12Hooks::SetRootSignatureTracking(true);
+
+        Dx12Contexts.erase(handleId);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    // Assign handle
     if (*OutHandle == nullptr)
-        *OutHandle = new NVSDK_NGX_Handle { handleId };
+        *OutHandle = new NVSDK_NGX_Handle{ handleId };
     else
         (*OutHandle)->Id = handleId;
 
-#pragma region Check for Dx12Device Device
-
-    if (!D3D12Device)
+    // Ensure D3D12 device
+    if (!EnsureD3D12Device(InCmdList))
     {
-        LOG_DEBUG("Get D3d12 device from InCmdList!");
-        auto deviceResult = InCmdList->GetDevice(IID_PPV_ARGS(&D3D12Device));
+        LOG_ERROR("Failed to acquire D3D12 device");
 
-        if (deviceResult != S_OK || !D3D12Device)
-        {
-            LOG_ERROR("Can't get Dx12Device from InCmdList!");
-            return NVSDK_NGX_Result_Fail;
-        }
+        if (shouldRestore)
+            D3D12Hooks::SetRootSignatureTracking(true);
+
+        // Partial cleanup – handle is allocated but context is incomplete
+        Dx12Contexts.erase(handleId);
+        return NVSDK_NGX_Result_Fail;
     }
 
-#pragma endregion
+    state.AutoExposure.reset();
 
-    State::Instance().AutoExposure.reset();
+    IFeature_Dx12* feature = Dx12Contexts[handleId].feature.get();
 
-    if (deviceContext->Init(D3D12Device, InCmdList, InParameters))
+    // Initialize feature
+    if (feature->Init(D3D12Device, InCmdList, InParameters))
     {
-        State::Instance().currentFeature = deviceContext;
+        state.currentFeature = feature;
         evalCounter = 0;
-
         UpscalerInputsDx12::Reset();
     }
     else
     {
-        LOG_ERROR("CreateFeature failed, returning to FSR 2.1.2 upscaler");
-        State::Instance().newBackend = "fsr21";
-        State::Instance().changeBackend[handleId] = true;
+        LOG_ERROR("Feature '{}' initialization failed falling back to FSR 2.1.2", featureName);
+        state.newBackend = "fsr21";
+        state.changeBackend[handleId] = true;
     }
 
-    if (Config::Instance()->RestoreComputeSignature.value_or_default() ||
-        Config::Instance()->RestoreGraphicSignature.value_or_default())
+    // Restore root signatures
+    if (shouldRestore)
     {
-        if (Config::Instance()->RestoreComputeSignature.value_or_default())
+        if (restoreCompute)
             D3D12Hooks::RestoreComputeRootSignature(InCmdList);
 
-        if (Config::Instance()->RestoreGraphicSignature.value_or_default())
+        if (restoreGraphic)
             D3D12Hooks::RestoreGraphicsRootSignature(InCmdList);
     }
 
     D3D12Hooks::SetRootSignatureTracking(true);
 
-    State::Instance().FGchanged = true;
+    state.FGchanged = true;
 
     return NVSDK_NGX_Result_Success;
+}
+
+/**
+ * @brief Instantiates a new feature based on the given unique feature ID and param table and
+ * provides a handle used to reference the feature elsewhere in the API. Currently supports
+ * various TSR and Frame Generation algorithms, including a special case for DLSS-RR passthrough.
+ */
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(
+    ID3D12GraphicsCommandList* InCmdList,
+    NVSDK_NGX_Feature InFeatureID,
+    NVSDK_NGX_Parameter* InParameters,
+    NVSDK_NGX_Handle** OutHandle)
+{
+    LOG_FUNC();
+
+    if (!InCmdList)
+    {
+        LOG_ERROR("InCmdList is null");
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    if (!OutHandle)
+    {
+        LOG_ERROR("OutHandle is null");
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    const State& state = State::Instance();
+    const Config& cfg = *Config::Instance();
+
+    // Nukem's DLSSG mod passthrough
+    if (state.activeFgInput == FGInput::Nukems && DLSSGMod::isDx12Available() &&
+        InFeatureID == NVSDK_NGX_Feature_FrameGeneration)
+    {
+        LOG_INFO("Passthrough to Nukem's DLSSG CreateFeature for FrameGeneration");
+
+        NVSDK_NGX_Result res = DLSSGMod::D3D12_CreateFeature(InCmdList, InFeatureID, InParameters, OutHandle);
+
+        if (*OutHandle)
+            LOG_INFO("Created modded DLSSG feature with HandleId: {}", (*OutHandle)->Id);
+
+        return res;
+    }
+
+    // Native DLSS passthrough (exclude SuperSampling and RayReconstruction)
+    if (InFeatureID != NVSDK_NGX_Feature_SuperSampling && InFeatureID != NVSDK_NGX_Feature_RayReconstruction)
+    {
+        if (cfg.DLSSEnabled.value_or_default() && NVNGXProxy::InitDx12(D3D12Device) &&
+            NVNGXProxy::D3D12_CreateFeature() != nullptr)
+        {
+            LOG_INFO("Passthrough to native NGX CreateFeature for feature {}", (int)InFeatureID);
+
+            NVSDK_NGX_Result res = NVNGXProxy::D3D12_CreateFeature()(InCmdList, InFeatureID, InParameters, OutHandle);
+
+            if (*OutHandle)
+                LOG_INFO("Native CreateFeature success, HandleId: {}", (*OutHandle)->Id);
+            else
+                LOG_INFO("Native CreateFeature failed: {:#x}", (uint32_t)res);
+
+            return res;
+        }
+
+        LOG_WARN("Native DLSS passthrough not available for feature {}", (int)InFeatureID);
+        return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
+    }
+
+    // OptiScaler internal handling (SuperSampling or RayReconstruction)
+    return TryCreateOptiFeature(InCmdList, InFeatureID, InParameters, OutHandle);
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* InHandle)
@@ -598,8 +702,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
         return NVSDK_NGX_Result_Success;
 
     auto handleId = InHandle->Id;
-
     State::Instance().FGchanged = true;
+
+    // Clean up framegen
     if (State::Instance().currentFG != nullptr && State::Instance().activeFgInput == FGInput::Upscaler)
     {
         State::Instance().currentFG->DestroyFGContext();
@@ -610,6 +715,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
     if (!shutdown)
         LOG_INFO("releasing feature with id {0}", handleId);
 
+    // OptiScaler handles start after this offset. If it's outside this range, it doesn't belong to OptiScaler.
     if (handleId < DLSS_MOD_ID_OFFSET)
     {
         if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::D3D12_ReleaseFeature() != nullptr)
@@ -617,10 +723,11 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             if (!shutdown)
                 LOG_INFO("calling D3D12_ReleaseFeature for ({0})", handleId);
 
+            // Clean up real DLSS feature
             auto result = NVNGXProxy::D3D12_ReleaseFeature()(InHandle);
 
             if (!shutdown)
-                LOG_INFO("D3D12_ReleaseFeature result for ({0}): {1:X}", handleId, (UINT) result);
+                LOG_INFO("D3D12_ReleaseFeature result for ({0}): {1:X}", handleId, (UINT)result);
 
             return result;
         }
@@ -632,47 +739,62 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             return NVSDK_NGX_Result_FAIL_FeatureNotFound;
         }
     }
+    // Clean up OptiScaler feature with framegen
     else if (State::Instance().activeFgInput == FGInput::Nukems && handleId >= DLSSG_MOD_ID_OFFSET)
     {
         LOG_INFO("D3D12_ReleaseFeature modded DLSSG with HandleId: {0}", handleId);
         return DLSSGMod::D3D12_ReleaseFeature(InHandle);
     }
 
-    if (auto deviceContext = Dx12Contexts[handleId].feature.get(); deviceContext != nullptr)
+    // Remove feature from context map
+    if (auto it = Dx12Contexts.find(handleId); it != Dx12Contexts.end())
     {
-        if (deviceContext == State::Instance().currentFeature)
-            State::Instance().currentFeature = nullptr;
+        auto& entry = it->second;
 
-        Dx12Contexts[handleId].feature.reset();
-        auto it = std::find_if(Dx12Contexts.begin(), Dx12Contexts.end(),
-                               [&handleId](const auto& p) { return p.first == handleId; });
-        Dx12Contexts.erase(it);
+        if (auto* deviceContext = entry.feature.get())
+        {
+            // Clear global reference if it matches
+            if (deviceContext == State::Instance().currentFeature)
+                State::Instance().currentFeature = nullptr;
+
+            // Erase from map (smart pointer reset is implicit on erase)
+            Dx12Contexts.erase(it);
+        }
     }
-    else
-    {
-        if (!shutdown)
-            LOG_ERROR("can't release feature with id {0}!", handleId);
-    }
+
+    // Fallback Error Handling
+    if (!shutdown)
+        LOG_ERROR("can't release feature with id {0}!", handleId);
 
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Used by the client application to check for feature support.
+ * @param Adapter Device the feature is for.
+ * @param FeatureDiscoveryInfo Specifies the feature being queried.
+ * @param OutSupported Used to indicate whether a feature is supported and its requirements.
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetFeatureRequirements(
-    IDXGIAdapter* Adapter, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo,
+    IDXGIAdapter* Adapter,
+    const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo,
     NVSDK_NGX_FeatureRequirement* OutSupported)
 {
-    LOG_DEBUG("for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
+    LOG_DEBUG("for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
 
     if (State::Instance().activeFgInput == FGInput::Nukems)
         DLSSGMod::InitDLSSGMod_Dx12();
 
     if (FeatureDiscoveryInfo->FeatureID == NVSDK_NGX_Feature_SuperSampling ||
         (FeatureDiscoveryInfo->FeatureID == NVSDK_NGX_Feature_FrameGeneration &&
-         ((DLSSGMod::isDx12Available() && Config::Instance()->FGInput == FGInput::Nukems) ||
-          Config::Instance()->FGInput == FGInput::DLSSG)))
+            ((DLSSGMod::isDx12Available() && Config::Instance()->FGInput == FGInput::Nukems) ||
+                Config::Instance()->FGInput == FGInput::DLSSG)))
     {
         if (OutSupported == nullptr)
-            OutSupported = new NVSDK_NGX_FeatureRequirement();
+        {
+            static auto tmp = NVSDK_NGX_FeatureRequirement();
+            OutSupported = &tmp;
+        }
 
         OutSupported->FeatureSupported = NVSDK_NGX_FeatureSupportResult_Supported;
         OutSupported->MinHWArchitecture = 0;
@@ -687,184 +809,217 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetFeatureRequirements(
 
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::D3D12_GetFeatureRequirements() != nullptr)
     {
-        LOG_DEBUG("D3D12_GetFeatureRequirements for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
+        LOG_DEBUG("D3D12_GetFeatureRequirements for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
         auto result = NVNGXProxy::D3D12_GetFeatureRequirements()(Adapter, FeatureDiscoveryInfo, OutSupported);
-        LOG_DEBUG("D3D12_GetFeatureRequirements result for ({0}): {1:X}", (int) FeatureDiscoveryInfo->FeatureID,
-                  (UINT) result);
+        LOG_DEBUG("D3D12_GetFeatureRequirements result for ({0}): {1:X}", (int)FeatureDiscoveryInfo->FeatureID,
+            (UINT)result);
 
         return result;
     }
     else
     {
-        LOG_DEBUG("D3D12_GetFeatureRequirements not available for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
+        LOG_DEBUG("D3D12_GetFeatureRequirements not available for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
     }
 
     OutSupported->FeatureSupported = NVSDK_NGX_FeatureSupportResult_AdapterUnsupported;
     return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
 }
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCommandList* InCmdList,
-                                                               const NVSDK_NGX_Handle* InFeatureHandle,
-                                                               NVSDK_NGX_Parameter* InParameters,
-                                                               PFN_NVSDK_NGX_ProgressCallback InCallback)
+static NVSDK_NGX_Result TryEvaluateOptiFeature(
+    ID3D12GraphicsCommandList* InCmdList,
+    const NVSDK_NGX_Handle* InFeatureHandle,
+    NVSDK_NGX_Parameter* InParameters,
+    PFN_NVSDK_NGX_ProgressCallback InCallback)
 {
-    if (InFeatureHandle == nullptr)
+    State& state = State::Instance();
+    const Config& cfg = *Config::Instance();
+    const uint32_t handleId = InFeatureHandle->Id;
+
+    auto ctxIt = Dx12Contexts.find(handleId);
+    if (ctxIt == Dx12Contexts.end())
     {
-        LOG_DEBUG("InFeatureHandle is null");
+        LOG_WARN("No context found for handle {}", handleId);
         return NVSDK_NGX_Result_FAIL_FeatureNotFound;
     }
 
-    if (InCmdList == nullptr)
-    {
-        LOG_ERROR("InCmdList is null!!!");
-        return NVSDK_NGX_Result_Fail;
-    }
+    ContextData<IFeature_Dx12>& ctxData = ctxIt->second;
+    IFeature_Dx12* feature = ctxData.feature.get();
 
-    LOG_DEBUG("Handle: {}, CmdList: {:X}", InFeatureHandle->Id, (size_t) InCmdList);
-    auto handleId = InFeatureHandle->Id;
-
-    if (handleId < DLSS_MOD_ID_OFFSET)
+    if (!feature)
     {
-        if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::D3D12_EvaluateFeature() != nullptr)
-        {
-            LOG_DEBUG("D3D12_EvaluateFeature for ({0})", handleId);
-            auto result = NVNGXProxy::D3D12_EvaluateFeature()(InCmdList, InFeatureHandle, InParameters, InCallback);
-            LOG_DEBUG("D3D12_EvaluateFeature result for ({0}): {1:X}", handleId, (UINT) result);
-            return result;
-        }
-        else
-        {
-            LOG_DEBUG("D3D12_EvaluateFeature not avaliable for ({0})", handleId);
-            return NVSDK_NGX_Result_FAIL_FeatureNotFound;
-        }
-    }
-    else if (State::Instance().activeFgInput == FGInput::Nukems && handleId >= DLSSG_MOD_ID_OFFSET)
-    {
-        return DLSSGMod::D3D12_EvaluateFeature(InCmdList, InFeatureHandle, InParameters, InCallback);
-    }
-
-    if (!Dx12Contexts.contains(handleId))
+        LOG_WARN("Feature pointer is null for handle {}", handleId);
         return NVSDK_NGX_Result_FAIL_FeatureNotFound;
-
-    auto deviceContext = &Dx12Contexts[handleId];
-
-    if (deviceContext->feature == nullptr) // prevent source api name flicker when dlssg is active
-        State::Instance().setInputApiName = State::Instance().currentInputApiName;
-
-    if (State::Instance().setInputApiName.length() == 0)
-    {
-        if (std::strcmp(State::Instance().currentInputApiName.c_str(), "DLSS") != 0)
-            State::Instance().currentInputApiName = "DLSS";
-    }
-    else
-    {
-        if (std::strcmp(State::Instance().currentInputApiName.c_str(), State::Instance().setInputApiName.c_str()) != 0)
-            State::Instance().currentInputApiName = State::Instance().setInputApiName;
     }
 
-    State::Instance().setInputApiName.clear();
+    // Prevent API name flicker (e.g., during backend transitions or DLSSG)
+    if (state.setInputApiName == state.currentInputApiName)
+        state.setInputApiName.clear();
 
+    const std::string_view targetApiName = state.setInputApiName.empty() ? "DLSS" : state.setInputApiName;
+
+    if (state.currentInputApiName != targetApiName)
+        state.currentInputApiName = targetApiName;
+
+    state.setInputApiName.clear();
     evalCounter++;
-    if (Config::Instance()->SkipFirstFrames.has_value() && evalCounter < Config::Instance()->SkipFirstFrames.value())
+
+    // Skip evaluation for the first N frames if configured
+    if (cfg.SkipFirstFrames.has_value() && evalCounter < cfg.SkipFirstFrames.value())
         return NVSDK_NGX_Result_Success;
 
     if (InCallback)
-        LOG_INFO("callback exist");
+        LOG_INFO("Progress callback provided but unused in synchronous OptiScaler path");
 
-    if (deviceContext->feature)
+    // Resolution change detection (only for upscalers that may require recreation)
+    const bool isFSR31OrLater = feature->Name().starts_with("FSR") && feature->Version() >= feature_version{ 3, 1, 0 };
+
+    if (!isFSR31OrLater && feature->UpdateOutputResolution(InParameters))
+        state.changeBackend[handleId] = true;
+
+    // Backend change or recreation requested
+    if (state.changeBackend.contains(handleId) && state.changeBackend[handleId])
     {
-        auto* feature = deviceContext->feature.get();
+        LOG_INFO("Performing backend change/recreation for handle {} to '{}'", handleId, state.newBackend);
 
-        // FSR 3.1 supports upscaleSize that doesn't need reinit to change output resolution
-        if (!(feature->Name().starts_with("FSR") && feature->Version() >= feature_version { 3, 1, 0 }) &&
-            feature->UpdateOutputResolution(InParameters))
-            State::Instance().changeBackend[handleId] = true;
-    }
-
-    // Change backend
-    if (State::Instance().changeBackend[handleId])
-    {
         UpscalerInputsDx12::Reset();
         D3D12Hooks::SetRootSignatureTracking(true);
 
-        FeatureProvider_Dx12::ChangeFeature(State::Instance().newBackend, D3D12Device, InCmdList, handleId,
-                                            InParameters, deviceContext);
+        FeatureProvider_Dx12::ChangeFeature(state.newBackend, D3D12Device, InCmdList, handleId, InParameters, &ctxData);
+        feature = ctxData.feature.get();
+
+        state.changeBackend.erase(handleId);
+
+        if (!state.newBackend.empty())
+            state.newBackend.clear();
 
         evalCounter = 0;
-
         return NVSDK_NGX_Result_Success;
     }
 
-    if (!deviceContext->feature->IsInited() && Config::Instance()->Dx12Upscaler.value_or_default() != "fsr21")
+    // Fallback to FSR 2.1.2 if feature failed to initialize and user didn't explicitly request it
+    if (!feature->IsInited() && cfg.Dx12Upscaler.value_or_default() != "fsr21")
     {
-        LOG_WARN("InCmdList {0} is not inited, falling back to FSR 2.1.2", deviceContext->feature->Name());
-        State::Instance().newBackend = "fsr21";
-        State::Instance().changeBackend[handleId] = true;
+        LOG_WARN("Feature '{}' failed to initialize. Falling back to FSR 2.1.2", feature->Name());
+        state.newBackend = "fsr21";
+        state.changeBackend[handleId] = true;
         return NVSDK_NGX_Result_Success;
     }
 
-    State::Instance().currentFeature = deviceContext->feature.get();
+    state.currentFeature = feature;
 
-    // Root signature restore
-    if (Config::Instance()->RestoreComputeSignature.value_or_default() ||
-        Config::Instance()->RestoreGraphicSignature.value_or_default())
-    {
+    // Root signature restoration setup
+    const bool restoreCompute = cfg.RestoreComputeSignature.value_or_default();
+    const bool restoreGraphic = cfg.RestoreGraphicSignature.value_or_default();
+    const bool shouldRestore = (feature->Name() != "DLSSD") && (restoreCompute || restoreGraphic);
+
+    if (shouldRestore)
         D3D12Hooks::SetRootSignatureTracking(false);
-    }
 
-    UpscalerInputsDx12::UpscaleStart(InCmdList, InParameters, deviceContext->feature.get());
-    FSR3FG::SetUpscalerInputs(InCmdList, InParameters, deviceContext->feature.get());
+    // Prepare upscaling inputs
+    UpscalerInputsDx12::UpscaleStart(InCmdList, InParameters, feature);
+    FSR3FG::SetUpscalerInputs(InCmdList, InParameters, feature);
 
-    // Record the first timestamp
-    if (State::Instance().workingMode != WorkingMode::Nvngx)
+    if (!state.isWorkingAsNvngx)
         UpscalerTimeDx12::UpscaleStart(InCmdList);
 
-    auto evalResult = false;
-
-    // Run upscaler
+    // Evaluate the feature
+    bool evalSuccess = false;
     {
-        ScopedSkipHeapCapture skipHeapCapture {};
-        evalResult = deviceContext->feature->Evaluate(InCmdList, InParameters);
+        ScopedSkipHeapCapture skip{};
+        evalSuccess = feature->Evaluate(InCmdList, InParameters);
     }
 
-    NVSDK_NGX_Result methodResult = evalResult ? NVSDK_NGX_Result_Success : NVSDK_NGX_Result_Fail;
-
-    if (evalResult)
+    // Cleanup on success
+    if (evalSuccess)
     {
-        // Upscaler time calc
-        // Record the second timestamp
-        if (State::Instance().workingMode != WorkingMode::Nvngx)
+        if (!state.isWorkingAsNvngx)
             UpscalerTimeDx12::UpscaleEnd(InCmdList);
 
-        // FG Dispatch
-        UpscalerInputsDx12::UpscaleEnd(InCmdList, InParameters, deviceContext->feature.get());
+        UpscalerInputsDx12::UpscaleEnd(InCmdList, InParameters, feature);
+    }
+    else
+    {
+        LOG_ERROR("Feature evaluation failed for '{}'", feature->Name());
     }
 
-    // Root signature restore
-    if (Config::Instance()->RestoreComputeSignature.value_or_default() ||
-        Config::Instance()->RestoreGraphicSignature.value_or_default())
+    // Restore root signatures
+    if (shouldRestore)
     {
-        if (Config::Instance()->RestoreComputeSignature.value_or_default())
+        if (restoreCompute)
             D3D12Hooks::RestoreComputeRootSignature(InCmdList);
 
-        if (Config::Instance()->RestoreGraphicSignature.value_or_default())
+        if (restoreGraphic)
             D3D12Hooks::RestoreGraphicsRootSignature(InCmdList);
     }
 
     D3D12Hooks::SetRootSignatureTracking(true);
 
-    LOG_DEBUG("Upscaling done: {}", evalResult);
+    return evalSuccess ? NVSDK_NGX_Result_Success : NVSDK_NGX_Result_Fail;
+}
 
-    return methodResult;
+/**
+ * @brief Per-frame feature execution. Runs a feature (upscaler, framegen, etc.) on a given command list using a
+ * preexisting feature instance referenced by a unique handle.
+ */
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(
+    ID3D12GraphicsCommandList* InCmdList,
+    const NVSDK_NGX_Handle* InFeatureHandle,
+    NVSDK_NGX_Parameter* InParameters,
+    PFN_NVSDK_NGX_ProgressCallback InCallback)
+{
+    if (!InFeatureHandle)
+    {
+        LOG_DEBUG("InFeatureHandle is null");
+        return NVSDK_NGX_Result_FAIL_FeatureNotFound;
+    }
+
+    if (!InCmdList)
+    {
+        LOG_ERROR("InCmdList is null");
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    const uint32_t handleId = InFeatureHandle->Id;
+    LOG_DEBUG("EvaluateFeature - Handle: {}, CmdList: {:p}", handleId, (void*)InCmdList);
+
+    const State& state = State::Instance();
+    const Config& cfg = *Config::Instance();
+
+    // Native DLSS passthrough
+    if (handleId < DLSS_MOD_ID_OFFSET)
+    {
+        if (cfg.DLSSEnabled.value_or_default() && NVNGXProxy::D3D12_EvaluateFeature() != nullptr)
+        {
+            LOG_DEBUG("Passthrough to native DLSS EvaluateFeature for handle {}", handleId);
+            NVSDK_NGX_Result result =
+                NVNGXProxy::D3D12_EvaluateFeature()(InCmdList, InFeatureHandle, InParameters, InCallback);
+            LOG_DEBUG("Native DLSS EvaluateFeature result: {:#x}", (uint32_t)result);
+            return result;
+        }
+
+        LOG_DEBUG("Native DLSS EvaluateFeature not available for handle {}", handleId);
+        return NVSDK_NGX_Result_FAIL_FeatureNotFound;
+    }
+
+    // Nukem's DLSSG mod passthrough
+    if (state.activeFgInput == FGInput::Nukems && handleId >= DLSSG_MOD_ID_OFFSET)
+    {
+        LOG_DEBUG("Passthrough to Nukem's DLSSG EvaluateFeature for handle {}", handleId);
+        return DLSSGMod::D3D12_EvaluateFeature(InCmdList, InFeatureHandle, InParameters, InCallback);
+    }
+
+    // OptiScaler internal handling
+    return TryEvaluateOptiFeature(InCmdList, InFeatureHandle, InParameters, InCallback);
 }
 
 #pragma endregion
 
 #pragma region DLSS Buffer Size Call
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId,
-                                                                    const NVSDK_NGX_Parameter* InParameters,
-                                                                    size_t* OutSizeInBytes)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetScratchBufferSize(
+    NVSDK_NGX_Feature InFeatureId,
+    const NVSDK_NGX_Parameter* InParameters,
+    size_t* OutSizeInBytes)
 {
     if (OutSizeInBytes == nullptr)
         return NVSDK_NGX_Result_FAIL_InvalidParameter;

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -32,10 +32,10 @@ static inline bool _skipInit = false;
 
 class ScopedInit
 {
-private:
+  private:
     bool previousState;
 
-public:
+  public:
     ScopedInit()
     {
         previousState = _skipInit;
@@ -44,19 +44,12 @@ public:
     ~ScopedInit() { _skipInit = previousState; }
 };
 
-static bool GetIsDlssModuleInited()
-{
-    return Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::IsDx12Inited();
-}
-
 #pragma region DLSS Init Calls
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
-    unsigned long long InApplicationId,
-    const wchar_t* InApplicationDataPath,
-    ID3D12Device* InDevice,
-    NVSDK_NGX_Version InSDKVersion,
-    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApplicationId,
+                                                        const wchar_t* InApplicationDataPath, ID3D12Device* InDevice,
+                                                        NVSDK_NGX_Version InSDKVersion,
+                                                        const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
 {
     LOG_FUNC();
 
@@ -80,8 +73,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
         {
             LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext");
             auto result = NVNGXProxy::D3D12_Init_Ext()(InApplicationId, InApplicationDataPath, InDevice, InSDKVersion,
-                InFeatureInfo);
-            LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext result: {0:X}", (UINT)result);
+                                                       InFeatureInfo);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init_Ext result: {0:X}", (UINT) result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -105,7 +98,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
     }
 
     LOG_INFO("AppId: {0}", InApplicationId);
-    LOG_INFO("SDK: {0:x}", (unsigned int)InSDKVersion);
+    LOG_INFO("SDK: {0:x}", (unsigned int) InSDKVersion);
     appDataPath = std::wstring(InApplicationDataPath);
 
     LOG_INFO("InApplicationDataPath {0}", wstring_to_string(appDataPath));
@@ -137,12 +130,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(
     return NVSDK_NGX_Result_Success;
 }
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(
-    unsigned long long InApplicationId,
-    const wchar_t* InApplicationDataPath,
-    ID3D12Device* InDevice,
-    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo,
-    NVSDK_NGX_Version InSDKVersion)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(unsigned long long InApplicationId,
+                                                    const wchar_t* InApplicationDataPath, ID3D12Device* InDevice,
+                                                    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo,
+                                                    NVSDK_NGX_Version InSDKVersion)
 {
     LOG_FUNC();
 
@@ -161,7 +152,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(
             auto result =
                 NVNGXProxy::D3D12_Init()(InApplicationId, InApplicationDataPath, InDevice, InFeatureInfo, InSDKVersion);
 
-            LOG_INFO("calling NVNGXProxy::D3D12_Init result: {0:X}", (UINT)result);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init result: {0:X}", (UINT) result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -180,7 +171,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(
     //     DLSSGMod::D3D12_Init(InApplicationId, InApplicationDataPath, InDevice, InFeatureInfo, InSDKVersion);
     // }
 
-    ScopedInit scopedInit{};
+    ScopedInit scopedInit {};
     auto result =
         NVSDK_NGX_D3D12_Init_Ext(InApplicationId, InApplicationDataPath, InDevice, InSDKVersion, InFeatureInfo);
 
@@ -188,14 +179,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(
     return result;
 }
 
-NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(
-    const char* InProjectId,
-    NVSDK_NGX_EngineType InEngineType,
-    const char* InEngineVersion,
-    const wchar_t* InApplicationDataPath,
-    ID3D12Device* InDevice,
-    NVSDK_NGX_Version InSDKVersion,
-    const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProjectId,
+                                                              NVSDK_NGX_EngineType InEngineType,
+                                                              const char* InEngineVersion,
+                                                              const wchar_t* InApplicationDataPath,
+                                                              ID3D12Device* InDevice, NVSDK_NGX_Version InSDKVersion,
+                                                              const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
 {
     LOG_FUNC();
 
@@ -213,9 +202,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(
 
             auto result =
                 NVNGXProxy::D3D12_Init_ProjectID()(InProjectId, InEngineType, InEngineVersion, InApplicationDataPath,
-                    InDevice, InSDKVersion, InFeatureInfo);
+                                                   InDevice, InSDKVersion, InFeatureInfo);
 
-            LOG_INFO("calling NVNGXProxy::D3D12_Init_ProjectID result: {0:X}", (UINT)result);
+            LOG_INFO("calling NVNGXProxy::D3D12_Init_ProjectID result: {0:X}", (UINT) result);
 
             if (result == NVSDK_NGX_Result_Success)
                 NVNGXProxy::SetDx12Inited(true);
@@ -223,7 +212,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(
     }
 
     LOG_INFO("InProjectId: {0}", InProjectId);
-    LOG_INFO("InEngineType: {0}", (int)InEngineType);
+    LOG_INFO("InEngineType: {0}", (int) InEngineType);
     LOG_INFO("InEngineVersion: {0}", InEngineVersion);
 
     State::Instance().NVNGX_ProjectId = std::string(InProjectId);
@@ -236,7 +225,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(
         return NVSDK_NGX_Result_Success;
     }
 
-    ScopedInit scopedInit{};
+    ScopedInit scopedInit {};
     auto result = NVSDK_NGX_D3D12_Init_Ext(0x1337, InApplicationDataPath, InDevice, InSDKVersion, InFeatureInfo);
     return result;
 }
@@ -250,7 +239,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_with_ProjectID(
     LOG_FUNC();
 
     LOG_INFO("InProjectId: {0}", InProjectId);
-    LOG_INFO("InEngineType: {0}", (int)InEngineType);
+    LOG_INFO("InEngineType: {0}", (int) InEngineType);
     LOG_INFO("InEngineVersion: {0}", InEngineVersion);
 
     State::Instance().NVNGX_ProjectId = std::string(InProjectId);
@@ -366,12 +355,13 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
     // If DLSS is enabled and the real DLSS module is loaded, get native NGX table
-    if (GetIsDlssModuleInited() && NVNGXProxy::D3D12_GetParameters() != nullptr)
+    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
+        NVNGXProxy::D3D12_GetParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters");
         auto result = NVNGXProxy::D3D12_GetParameters()(OutParameters);
-        LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters result: {0:X}, ptr: {1:X}", (UINT)result,
-            (UINT64)*OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetParameters result: {0:X}, ptr: {1:X}", (UINT) result,
+                 (UINT64) *OutParameters);
 
         // Copy OptiScaler config to real NGX param table
         if (result == NVSDK_NGX_Result_Success)
@@ -391,9 +381,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetParameters(NVSDK_NGX_Parameter
 }
 
 /**
- * @brief Allocates a new NVSDK parameter map pre-populated with NGX capabilities and information about available features.
- * The output parameter map may also be used in the same ways as a parameter map allocated with AllocateParameters().
- * The lifetime of this map is managed by the calling application with DestroyParameters().
+ * @brief Allocates a new NVSDK parameter map pre-populated with NGX capabilities and information about available
+ * features. The output parameter map may also be used in the same ways as a parameter map allocated with
+ * AllocateParameters(). The lifetime of this map is managed by the calling application with DestroyParameters().
  */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
@@ -403,12 +393,13 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetCapabilityParameters(NVSDK_NGX
         return NVSDK_NGX_Result_FAIL_InvalidParameter;
 
     // Get native DLSS params if DLSS is enabled and the module is loaded
-    if (GetIsDlssModuleInited() && NVNGXProxy::IsDx12Inited() && NVNGXProxy::D3D12_GetCapabilityParameters() != nullptr)
+    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
+        NVNGXProxy::IsDx12Inited() && NVNGXProxy::D3D12_GetCapabilityParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters");
         auto result = NVNGXProxy::D3D12_GetCapabilityParameters()(OutParameters);
-        LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters result: {0:X}, ptr: {1:X}", (UINT)result,
-            (UINT64)*OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_GetCapabilityParameters result: {0:X}, ptr: {1:X}", (UINT) result,
+                 (UINT64) *OutParameters);
 
         if (result == NVSDK_NGX_Result_Success)
         {
@@ -435,12 +426,13 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_AllocateParameters(NVSDK_NGX_Para
 {
     LOG_FUNC();
 
-    if (GetIsDlssModuleInited() && NVNGXProxy::D3D12_AllocateParameters() != nullptr)
+    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
+        NVNGXProxy::D3D12_AllocateParameters() != nullptr)
     {
         LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters");
         auto result = NVNGXProxy::D3D12_AllocateParameters()(OutParameters);
-        LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters result: {0:X}, ptr: {1:X}", (UINT)result,
-            (UINT64)*OutParameters);
+        LOG_INFO("Calling NVNGXProxy::D3D12_AllocateParameters result: {0:X}, ptr: {1:X}", (UINT) result,
+                 (UINT64) *OutParameters);
 
         if (result == NVSDK_NGX_Result_Success)
         {
@@ -523,11 +515,8 @@ static bool EnsureD3D12Device(ID3D12GraphicsCommandList* cmdList)
     return true;
 }
 
-static NVSDK_NGX_Result TryCreateOptiFeature(
-    ID3D12GraphicsCommandList* InCmdList,
-    NVSDK_NGX_Feature InFeatureID,
-    NVSDK_NGX_Parameter* InParameters,
-    NVSDK_NGX_Handle** OutHandle)
+static NVSDK_NGX_Result TryCreateOptiFeature(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_Feature InFeatureID,
+                                             NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
 {
     State& state = State::Instance();
     const Config& cfg = *Config::Instance();
@@ -674,19 +663,19 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsComma
         if (cfg.DLSSEnabled.value_or_default() && NVNGXProxy::InitDx12(D3D12Device) &&
             NVNGXProxy::D3D12_CreateFeature() != nullptr)
         {
-            LOG_INFO("Passthrough to native NGX CreateFeature for feature {}", (int)InFeatureID);
+            LOG_INFO("Passthrough to native NGX CreateFeature for feature {}", (int) InFeatureID);
 
             NVSDK_NGX_Result res = NVNGXProxy::D3D12_CreateFeature()(InCmdList, InFeatureID, InParameters, OutHandle);
 
             if (*OutHandle)
                 LOG_INFO("Native CreateFeature success, HandleId: {}", (*OutHandle)->Id);
             else
-                LOG_INFO("Native CreateFeature failed: {:#x}", (uint32_t)res);
+                LOG_INFO("Native CreateFeature failed: {:#x}", (uint32_t) res);
 
             return res;
         }
 
-        LOG_WARN("Native DLSS passthrough not available for feature {}", (int)InFeatureID);
+        LOG_WARN("Native DLSS passthrough not available for feature {}", (int) InFeatureID);
         return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
     }
 
@@ -727,7 +716,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             auto result = NVNGXProxy::D3D12_ReleaseFeature()(InHandle);
 
             if (!shutdown)
-                LOG_INFO("D3D12_ReleaseFeature result for ({0}): {1:X}", handleId, (UINT)result);
+                LOG_INFO("D3D12_ReleaseFeature result for ({0}): {1:X}", handleId, (UINT) result);
 
             return result;
         }
@@ -761,10 +750,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             Dx12Contexts.erase(it);
         }
     }
-
-    // Fallback Error Handling
-    if (!shutdown)
-        LOG_ERROR("can't release feature with id {0}!", handleId);
+    else
+    {
+        // Fallback Error Handling
+        if (!shutdown)
+            LOG_ERROR("can't release feature with id {0}!", handleId);
+    }
 
     return NVSDK_NGX_Result_Success;
 }
@@ -776,19 +767,18 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
  * @param OutSupported Used to indicate whether a feature is supported and its requirements.
  */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetFeatureRequirements(
-    IDXGIAdapter* Adapter,
-    const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo,
+    IDXGIAdapter* Adapter, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo,
     NVSDK_NGX_FeatureRequirement* OutSupported)
 {
-    LOG_DEBUG("for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
+    LOG_DEBUG("for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
 
     if (State::Instance().activeFgInput == FGInput::Nukems)
         DLSSGMod::InitDLSSGMod_Dx12();
 
     if (FeatureDiscoveryInfo->FeatureID == NVSDK_NGX_Feature_SuperSampling ||
         (FeatureDiscoveryInfo->FeatureID == NVSDK_NGX_Feature_FrameGeneration &&
-            ((DLSSGMod::isDx12Available() && Config::Instance()->FGInput == FGInput::Nukems) ||
-                Config::Instance()->FGInput == FGInput::DLSSG)))
+         ((DLSSGMod::isDx12Available() && Config::Instance()->FGInput == FGInput::Nukems) ||
+          Config::Instance()->FGInput == FGInput::DLSSG)))
     {
         if (OutSupported == nullptr)
         {
@@ -809,16 +799,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_GetFeatureRequirements(
 
     if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::D3D12_GetFeatureRequirements() != nullptr)
     {
-        LOG_DEBUG("D3D12_GetFeatureRequirements for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
+        LOG_DEBUG("D3D12_GetFeatureRequirements for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
         auto result = NVNGXProxy::D3D12_GetFeatureRequirements()(Adapter, FeatureDiscoveryInfo, OutSupported);
-        LOG_DEBUG("D3D12_GetFeatureRequirements result for ({0}): {1:X}", (int)FeatureDiscoveryInfo->FeatureID,
-            (UINT)result);
+        LOG_DEBUG("D3D12_GetFeatureRequirements result for ({0}): {1:X}", (int) FeatureDiscoveryInfo->FeatureID,
+                  (UINT) result);
 
         return result;
     }
     else
     {
-        LOG_DEBUG("D3D12_GetFeatureRequirements not available for ({0})", (int)FeatureDiscoveryInfo->FeatureID);
+        LOG_DEBUG("D3D12_GetFeatureRequirements not available for ({0})", (int) FeatureDiscoveryInfo->FeatureID);
     }
 
     OutSupported->FeatureSupported = NVSDK_NGX_FeatureSupportResult_AdapterUnsupported;
@@ -901,7 +891,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(ID3D12GraphicsCommandList* InCmdL
     // Root signature restoration setup
     const bool restoreCompute = cfg.RestoreComputeSignature.value_or_default();
     const bool restoreGraphic = cfg.RestoreGraphicSignature.value_or_default();
-    const bool shouldRestore = (feature->Name() != "DLSSD") && (restoreCompute || restoreGraphic);
+    const bool shouldRestore = restoreCompute || restoreGraphic;
 
     if (shouldRestore)
         D3D12Hooks::SetRootSignatureTracking(false);
@@ -916,7 +906,7 @@ static NVSDK_NGX_Result TryEvaluateOptiFeature(ID3D12GraphicsCommandList* InCmdL
     // Evaluate the feature
     bool evalSuccess = false;
     {
-        ScopedSkipHeapCapture skip{};
+        ScopedSkipHeapCapture skip {};
         evalSuccess = feature->Evaluate(InCmdList, InParameters);
     }
 
@@ -970,7 +960,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
     }
 
     const uint32_t handleId = InFeatureHandle->Id;
-    LOG_DEBUG("EvaluateFeature - Handle: {}, CmdList: {:p}", handleId, (void*)InCmdList);
+    LOG_DEBUG("EvaluateFeature - Handle: {}, CmdList: {:p}", handleId, (void*) InCmdList);
 
     const State& state = State::Instance();
     const Config& cfg = *Config::Instance();
@@ -983,7 +973,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
             LOG_DEBUG("Passthrough to native DLSS EvaluateFeature for handle {}", handleId);
             NVSDK_NGX_Result result =
                 NVNGXProxy::D3D12_EvaluateFeature()(InCmdList, InFeatureHandle, InParameters, InCallback);
-            LOG_DEBUG("Native DLSS EvaluateFeature result: {:#x}", (uint32_t)result);
+            LOG_DEBUG("Native DLSS EvaluateFeature result: {:#x}", (uint32_t) result);
             return result;
         }
 

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -573,12 +573,6 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
         return NVSDK_NGX_Result_Fail;
     }
 
-    // Assign handle
-    if (*OutHandle == nullptr)
-        *OutHandle = new NVSDK_NGX_Handle{ handleId };
-    else
-        (*OutHandle)->Id = handleId;
-
     // Ensure D3D12 device
     if (!EnsureD3D12Device(InCmdList))
     {
@@ -587,10 +581,16 @@ static NVSDK_NGX_Result TryCreateOptiFeature(
         if (shouldRestore)
             D3D12Hooks::SetRootSignatureTracking(true);
 
-        // Partial cleanup â€“ handle is allocated but context is incomplete
+        // Partial cleanup – handle is allocated but context is incomplete
         Dx12Contexts.erase(handleId);
         return NVSDK_NGX_Result_Fail;
     }
+
+    // Assign handle
+    if (*OutHandle == nullptr)
+        *OutHandle = new NVSDK_NGX_Handle { handleId };
+    else
+        (*OutHandle)->Id = handleId;
 
     state.AutoExposure.reset();
 

--- a/OptiScaler/inputs/NVNGX_DLSS_Vk.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Vk.cpp
@@ -308,6 +308,12 @@ NVSDK_NGX_VULKAN_Init_ProjectID(const char* InProjectId, NVSDK_NGX_EngineType In
                                                InInstance, InPD, InDevice, InGIPA, InGDPA, InSDKVersion, InFeatureInfo);
 }
 
+/**
+ * @brief [Deprecated NGX API] Superceeded by NVSDK_NGX_AllocateParameters and NVSDK_NGX_GetCapabilityParameters.
+ *
+ * Retrieves a common NVSDK parameter map for providing params to the SDK. The lifetime of this
+ * map is NOT managed by the application. It is expected to be managed internally by the SDK.
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -325,11 +331,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetParameters(NVSDK_NGX_Paramete
         if (result == NVSDK_NGX_Result_Success)
         {
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVPersistent);
             return result;
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiVk");
+    // Get custom parameters if using custom backend
+    static NVNGX_Parameters oldParams = NVNGX_Parameters("OptiVk", true);
+    *OutParameters = &oldParams;
+    InitNGXParameters(*OutParameters);
+
     return NVSDK_NGX_Result_Success;
 }
 
@@ -506,6 +517,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetFeatureDeviceExtensionRequire
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Allocates a new parameter map used to provide parameters needed by the DLSS API. The lifetime of this map
+ * is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_AllocateParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -518,11 +533,13 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_AllocateParameters(NVSDK_NGX_Par
         LOG_INFO("NVNGXProxy::VULKAN_AllocateParameters result: {0:X}", (UINT) result);
 
         if (result == NVSDK_NGX_Result_Success)
+        {
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return result;
+        }
     }
 
-    auto params = new NVNGX_Parameters();
-    params->Name = "OptiVk";
+    auto* params = new NVNGX_Parameters("OptiVk", false);
     *OutParameters = params;
 
     return NVSDK_NGX_Result_Success;
@@ -576,6 +593,11 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetFeatureRequirements(
     return NVSDK_NGX_Result_FAIL_FeatureNotSupported;
 }
 
+/**
+ * @brief Allocates a new NVSDK parameter map pre-populated with NGX capabilities and information about available
+ * features. The output parameter map may also be used in the same ways as a parameter map allocated with
+ * AllocateParameters(). The lifetime of this map is managed by the calling application with DestroyParameters().
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetCapabilityParameters(NVSDK_NGX_Parameter** OutParameters)
 {
     LOG_FUNC();
@@ -592,12 +614,17 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetCapabilityParameters(NVSDK_NG
 
         if (result == NVSDK_NGX_Result_Success)
         {
+            // Init external NGX table with current configuration and mark as dynamic+external
             InitNGXParameters(*OutParameters);
+            SetNGXParamAllocType(*(*OutParameters), NGX_AllocTypes::NVDynamic);
             return result;
         }
     }
 
-    *OutParameters = GetNGXParameters("OptiVk");
+    // Get custom parameters if using custom backend
+    auto& params = *(new NVNGX_Parameters("OptiVk", false));
+    InitNGXParameters(&params);
+    *OutParameters = &params;
 
     return NVSDK_NGX_Result_Success;
 }
@@ -616,6 +643,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_PopulateParameters_Impl(NVSDK_NG
     return NVSDK_NGX_Result_Success;
 }
 
+/**
+ * @brief Destroys a given input parameter map created with AllocateParameters or GetCapabilityParameters.
+ Must not be called on maps returned by GetParameters(). Unsupported tables will not be freed.
+ */
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_DestroyParameters(NVSDK_NGX_Parameter* InParameters)
 {
     LOG_FUNC();
@@ -623,20 +654,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_DestroyParameters(NVSDK_NGX_Para
     if (InParameters == nullptr)
         return NVSDK_NGX_Result_Fail;
 
-    if (Config::Instance()->DLSSEnabled.value_or_default() && NVNGXProxy::NVNGXModule() != nullptr &&
-        NVNGXProxy::VULKAN_DestroyParameters() != nullptr)
-    {
-        LOG_INFO("calling NVNGXProxy::VULKAN_DestroyParameters");
-        auto result = NVNGXProxy::VULKAN_DestroyParameters()(InParameters);
-        LOG_INFO("calling NVNGXProxy::VULKAN_DestroyParameters result: {0:X}", (UINT) result);
+    const bool success = TryDestroyNGXParameters(InParameters, NVNGXProxy::VULKAN_DestroyParameters());
 
-        return result;
-    }
-
-    delete InParameters;
-    InParameters = nullptr;
-
-    return NVSDK_NGX_Result_Success;
+    return success ? NVSDK_NGX_Result_Success : NVSDK_NGX_Result_Fail;
 }
 
 NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId,

--- a/OptiScaler/upscalers/FeatureProvider_Dx11.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Dx11.cpp
@@ -19,6 +19,9 @@
 bool FeatureProvider_Dx11::GetFeature(std::string upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
                                       std::unique_ptr<IFeature_Dx11>* feature)
 {
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
+
     do
     {
         if (upscalerName == "xess")
@@ -57,14 +60,14 @@ bool FeatureProvider_Dx11::GetFeature(std::string upscalerName, UINT handleId, N
             break;
         }
 
-        if (Config::Instance()->DLSSEnabled.value_or_default())
+        if (cfg.DLSSEnabled.value_or_default())
         {
-            if (upscalerName == "dlss" && State::Instance().NVNGX_DLSS_Path.has_value())
+            if (upscalerName == "dlss" && state.NVNGX_DLSS_Path.has_value())
             {
                 *feature = std::make_unique<DLSSFeatureDx11>(handleId, parameters);
                 break;
             }
-            else if (upscalerName == "dlssd" && State::Instance().NVNGX_DLSSD_Path.has_value())
+            else if (upscalerName == "dlssd" && state.NVNGX_DLSSD_Path.has_value())
             {
                 *feature = std::make_unique<DLSSDFeatureDx11>(handleId, parameters);
                 break;
@@ -89,7 +92,7 @@ bool FeatureProvider_Dx11::GetFeature(std::string upscalerName, UINT handleId, N
     }
     else
     {
-        Config::Instance()->Dx11Upscaler = upscalerName;
+        cfg.Dx11Upscaler = upscalerName;
     }
 
     auto result = (*feature)->ModuleLoaded();
@@ -99,19 +102,25 @@ bool FeatureProvider_Dx11::GetFeature(std::string upscalerName, UINT handleId, N
         if (upscalerName == "dlssd")
             upscalerName = "dlss";
 
-        Config::Instance()->Dx11Upscaler = upscalerName;
+        cfg.Dx11Upscaler = upscalerName;
     }
 
     return result;
 }
 
-bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device* device,
-                                         ID3D11DeviceContext* devContext, UINT handleId,
-                                         NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx11>* contextData)
+bool FeatureProvider_Dx11::ChangeFeature(
+    std::string upscalerName, 
+    ID3D11Device* device,
+    ID3D11DeviceContext* devContext, 
+    UINT handleId,
+    NVSDK_NGX_Parameter* parameters, 
+    ContextData<IFeature_Dx11>* contextData)
 {
-    if (State::Instance().newBackend == "" ||
-        (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
-        State::Instance().newBackend = Config::Instance()->Dx11Upscaler.value_or_default();
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
+
+    if (state.newBackend == "" ||  (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
+        state.newBackend = cfg.Dx11Upscaler.value_or_default();
 
     contextData->changeBackendCounter++;
 
@@ -120,15 +129,14 @@ bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device*
     {
         if (contextData->feature != nullptr)
         {
-            LOG_INFO("changing backend to {0}", State::Instance().newBackend);
+            LOG_INFO("changing backend to {0}", state.newBackend);
 
-            auto dc = contextData->feature.get();
+            auto* dc = contextData->feature.get();
+            // Use given params if using DLSS passthrough
+            const std::string_view backend = state.newBackend;
+            const bool isPassthrough = backend == "dlssd" || backend == "dlss";
 
-            if (State::Instance().newBackend != "dlssd" && State::Instance().newBackend != "dlss")
-                contextData->createParams = GetNGXParameters("OptiDx11");
-            else
-                contextData->createParams = parameters;
-
+            contextData->createParams = isPassthrough ? parameters : GetNGXParameters("OptiDx11", false);
             contextData->createParams->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, dc->GetFeatureFlags());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Width, dc->RenderWidth());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Height, dc->RenderHeight());
@@ -148,12 +156,12 @@ bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device*
         {
             LOG_ERROR("can't find handle {0} in Dx11Contexts!", handleId);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
 
             if (contextData->createParams != nullptr)
             {
-                free(contextData->createParams);
+                TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::D3D11_DestroyParameters());
                 contextData->createParams = nullptr;
             }
 
@@ -165,11 +173,11 @@ bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device*
 
     if (contextData->changeBackendCounter == 2)
     {
-        LOG_INFO("Creating new {} upscaler", State::Instance().newBackend);
+        LOG_INFO("Creating new {} upscaler", state.newBackend);
 
         contextData->feature.reset();
 
-        if (!GetFeature(State::Instance().newBackend, handleId, contextData->createParams, &contextData->feature))
+        if (!GetFeature(state.newBackend, handleId, contextData->createParams, &contextData->feature))
         {
             LOG_ERROR("Upscaler can't created");
             return false;
@@ -183,7 +191,7 @@ bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device*
         // then init and continue
         auto initResult = contextData->feature->Init(device, devContext, contextData->createParams);
 
-        if (Config::Instance()->Dx11DelayedInit.value_or_default())
+        if (cfg.Dx11DelayedInit.value_or_default())
         {
             LOG_TRACE("sleeping after new Init of new feature for 1000ms");
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
@@ -193,39 +201,39 @@ bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device*
 
         if (!initResult || !contextData->feature->ModuleLoaded())
         {
-            LOG_ERROR("init failed with {0} feature", State::Instance().newBackend);
+            LOG_ERROR("init failed with {0} feature", state.newBackend);
 
-            if (State::Instance().newBackend != "dlssd")
+            if (state.newBackend != "dlssd")
             {
-                State::Instance().newBackend = "fsr22";
-                State::Instance().changeBackend[handleId] = true;
+                state.newBackend = "fsr22";
+                state.changeBackend[handleId] = true;
             }
             else
             {
-                State::Instance().newBackend = "";
-                State::Instance().changeBackend[handleId] = false;
+                state.newBackend = "";
+                state.changeBackend[handleId] = false;
                 return false;
             }
         }
         else
         {
-            LOG_INFO("init successful for {0}, upscaler changed", State::Instance().newBackend);
+            LOG_INFO("init successful for {0}, upscaler changed", state.newBackend);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
         }
 
         // if opti nvparam release it
         int optiParam = 0;
         if (contextData->createParams->Get("OptiScaler", &optiParam) == NVSDK_NGX_Result_Success && optiParam == 1)
         {
-            free(contextData->createParams);
+            TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::D3D11_DestroyParameters());
             contextData->createParams = nullptr;
         }
     }
 
     // if initial feature can't be inited
-    State::Instance().currentFeature = contextData->feature.get();
+    state.currentFeature = contextData->feature.get();
 
     return true;
 }

--- a/OptiScaler/upscalers/FeatureProvider_Dx11.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Dx11.cpp
@@ -108,18 +108,14 @@ bool FeatureProvider_Dx11::GetFeature(std::string upscalerName, UINT handleId, N
     return result;
 }
 
-bool FeatureProvider_Dx11::ChangeFeature(
-    std::string upscalerName, 
-    ID3D11Device* device,
-    ID3D11DeviceContext* devContext, 
-    UINT handleId,
-    NVSDK_NGX_Parameter* parameters, 
-    ContextData<IFeature_Dx11>* contextData)
+bool FeatureProvider_Dx11::ChangeFeature(std::string upscalerName, ID3D11Device* device,
+                                         ID3D11DeviceContext* devContext, UINT handleId,
+                                         NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx11>* contextData)
 {
     State& state = State::Instance();
     Config& cfg = *Config::Instance();
 
-    if (state.newBackend == "" ||  (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
+    if (state.newBackend == "" || (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
         state.newBackend = cfg.Dx11Upscaler.value_or_default();
 
     contextData->changeBackendCounter++;

--- a/OptiScaler/upscalers/FeatureProvider_Dx12.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Dx12.cpp
@@ -14,11 +14,8 @@
 #include "upscalers/xess/XeSSFeature_Dx12.h"
 #include "FeatureProvider_Dx11.h"
 
-bool FeatureProvider_Dx12::GetFeature(
-    std::string_view upscalerName, 
-    UINT handleId, 
-    NVSDK_NGX_Parameter* parameters,
-    std::unique_ptr<IFeature_Dx12>* feature)
+bool FeatureProvider_Dx12::GetFeature(std::string_view upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
+                                      std::unique_ptr<IFeature_Dx12>* feature)
 {
     State& state = State::Instance();
     Config& cfg = *Config::Instance();
@@ -81,13 +78,9 @@ bool FeatureProvider_Dx12::GetFeature(
     return loaded;
 }
 
-bool FeatureProvider_Dx12::ChangeFeature(
-    std::string_view upscalerName, 
-    ID3D12Device* device,                                   
-    ID3D12GraphicsCommandList* cmdList, 
-    UINT handleId,
-    NVSDK_NGX_Parameter* parameters, 
-    ContextData<IFeature_Dx12>* contextData)
+bool FeatureProvider_Dx12::ChangeFeature(std::string_view upscalerName, ID3D12Device* device,
+                                         ID3D12GraphicsCommandList* cmdList, UINT handleId,
+                                         NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx12>* contextData)
 {
     State& state = State::Instance();
     Config& cfg = *Config::Instance();
@@ -108,8 +101,7 @@ bool FeatureProvider_Dx12::ChangeFeature(
     // first release everything
     if (contextData->changeBackendCounter == 1)
     {
-        if (state.currentFG != nullptr && state.currentFG->IsActive() &&
-            state.activeFgInput == FGInput::Upscaler)
+        if (state.currentFG != nullptr && state.currentFG->IsActive() && state.activeFgInput == FGInput::Upscaler)
         {
             state.currentFG->DestroyFGContext();
             state.FGchanged = true;

--- a/OptiScaler/upscalers/FeatureProvider_Dx12.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Dx12.cpp
@@ -1,4 +1,4 @@
-#include <pch.h>
+#include "pch.h"
 #include "FeatureProvider_Dx12.h"
 
 #include "Util.h"
@@ -14,92 +14,92 @@
 #include "upscalers/xess/XeSSFeature_Dx12.h"
 #include "FeatureProvider_Dx11.h"
 
-bool FeatureProvider_Dx12::GetFeature(std::string upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
-                                      std::unique_ptr<IFeature_Dx12>* feature)
+bool FeatureProvider_Dx12::GetFeature(
+    std::string_view upscalerName, 
+    UINT handleId, 
+    NVSDK_NGX_Parameter* parameters,
+    std::unique_ptr<IFeature_Dx12>* feature)
 {
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
     ScopedSkipHeapCapture skipHeapCapture {};
+    std::string_view config_upscaler(upscalerName);
 
-    do
+    if (upscalerName == "xess")
     {
-        if (upscalerName == "xess")
+        *feature = std::make_unique<XeSSFeatureDx12>(handleId, parameters);
+    }
+    else if (upscalerName == "fsr21")
+    {
+        *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
+    }
+    else if (upscalerName == "fsr22")
+    {
+        *feature = std::make_unique<FSR2FeatureDx12>(handleId, parameters);
+    }
+    else if (upscalerName == "fsr31")
+    {
+        *feature = std::make_unique<FSR31FeatureDx12>(handleId, parameters);
+    }
+    else if (cfg.DLSSEnabled.value_or_default())
+    {
+        if (upscalerName == "dlss" && state.NVNGX_DLSS_Path.has_value())
         {
-            *feature = std::make_unique<XeSSFeatureDx12>(handleId, parameters);
-            break;
+            *feature = std::make_unique<DLSSFeatureDx12>(handleId, parameters);
         }
-        else if (upscalerName == "fsr21")
+        else if (upscalerName == "dlssd" && state.NVNGX_DLSSD_Path.has_value())
         {
-            *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
-            break;
-        }
-        else if (upscalerName == "fsr22")
-        {
-            *feature = std::make_unique<FSR2FeatureDx12>(handleId, parameters);
-            break;
-        }
-        else if (upscalerName == "fsr31")
-        {
-            *feature = std::make_unique<FSR31FeatureDx12>(handleId, parameters);
-            break;
-        }
-
-        if (Config::Instance()->DLSSEnabled.value_or_default())
-        {
-            if (upscalerName == "dlss" && State::Instance().NVNGX_DLSS_Path.has_value())
-            {
-                *feature = std::make_unique<DLSSFeatureDx12>(handleId, parameters);
-                break;
-            }
-            else if (upscalerName == "dlssd" && State::Instance().NVNGX_DLSSD_Path.has_value())
-            {
-                *feature = std::make_unique<DLSSDFeatureDx12>(handleId, parameters);
-                break;
-            }
-            else
-            {
-                *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
-            }
+            *feature = std::make_unique<DLSSDFeatureDx12>(handleId, parameters);
         }
         else
         {
             *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
+            config_upscaler = "fsr21";
         }
-
-    } while (false);
-
-    if (!(*feature)->ModuleLoaded())
-    {
-        (*feature).reset();
-        *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
-        upscalerName = "fsr21";
     }
     else
     {
-        Config::Instance()->Dx12Upscaler = upscalerName;
+        *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
+        config_upscaler = "fsr21";
     }
 
-    auto result = (*feature)->ModuleLoaded();
+    bool loaded = (*feature)->ModuleLoaded();
 
-    if (result)
+    if (!loaded)
     {
-        if (upscalerName == "dlssd")
-            upscalerName = "dlss";
-
-        Config::Instance()->Dx12Upscaler = upscalerName;
+        *feature = std::make_unique<FSR2FeatureDx12_212>(handleId, parameters);
+        config_upscaler = "fsr21";
+        loaded = true; // Assuming the fallback always loads successfully
     }
 
-    return result;
+    // Handle display name normalization for DLSSD
+    if (config_upscaler == "dlssd")
+        config_upscaler = "dlss";
+
+    cfg.Dx12Upscaler = std::string(config_upscaler);
+
+    return loaded;
 }
 
-bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device* device,
-                                         ID3D12GraphicsCommandList* cmdList, UINT handleId,
-                                         NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx12>* contextData)
+bool FeatureProvider_Dx12::ChangeFeature(
+    std::string_view upscalerName, 
+    ID3D12Device* device,                                   
+    ID3D12GraphicsCommandList* cmdList, 
+    UINT handleId,
+    NVSDK_NGX_Parameter* parameters, 
+    ContextData<IFeature_Dx12>* contextData)
 {
-    if (!State::Instance().changeBackend[handleId])
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
+
+    if (!state.changeBackend[handleId])
         return false;
 
-    if (State::Instance().newBackend == "" ||
-        (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
-        State::Instance().newBackend = Config::Instance()->Dx12Upscaler.value_or_default();
+    const bool isDlssBeingEnabled = !cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss";
+
+    // If no name or if dlss is being enabled use the configured upscaler name
+    if (state.newBackend == "" || isDlssBeingEnabled)
+        state.newBackend = cfg.Dx12Upscaler.value_or_default();
 
     contextData->changeBackendCounter++;
 
@@ -108,25 +108,24 @@ bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device*
     // first release everything
     if (contextData->changeBackendCounter == 1)
     {
-        if (State::Instance().currentFG != nullptr && State::Instance().currentFG->IsActive() &&
-            State::Instance().activeFgInput == FGInput::Upscaler)
+        if (state.currentFG != nullptr && state.currentFG->IsActive() &&
+            state.activeFgInput == FGInput::Upscaler)
         {
-            State::Instance().currentFG->DestroyFGContext();
-            State::Instance().FGchanged = true;
-            State::Instance().ClearCapturedHudlesses = true;
+            state.currentFG->DestroyFGContext();
+            state.FGchanged = true;
+            state.ClearCapturedHudlesses = true;
         }
 
         if (contextData->feature != nullptr)
         {
-            LOG_INFO("changing backend to {}", State::Instance().newBackend);
+            LOG_INFO("changing backend to {}", state.newBackend);
 
-            auto dc = contextData->feature.get();
+            auto* dc = contextData->feature.get();
+            // Use given params if using DLSS passthrough
+            const std::string_view backend = state.newBackend;
+            const bool isPassthrough = backend == "dlssd" || backend == "dlss";
 
-            if (State::Instance().newBackend != "dlssd" && State::Instance().newBackend != "dlss")
-                contextData->createParams = GetNGXParameters("OptiDx12");
-            else
-                contextData->createParams = parameters;
-
+            contextData->createParams = isPassthrough ? parameters : GetNGXParameters("OptiDx12", false);
             contextData->createParams->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, dc->GetFeatureFlags());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Width, dc->RenderWidth());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Height, dc->RenderHeight());
@@ -138,7 +137,7 @@ bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device*
 
             State::Instance().currentFeature = nullptr;
 
-            if (State::Instance().gameQuirks & GameQuirk::FastFeatureReset)
+            if (state.gameQuirks & GameQuirk::FastFeatureReset)
             {
                 LOG_DEBUG("sleeping before reset of current feature for 100ms (Fast Feature Reset)");
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -152,16 +151,16 @@ bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device*
             contextData->feature.reset();
             contextData->feature = nullptr;
         }
-        else
+        else // Clean up state if no feature is set
         {
             LOG_ERROR("can't find handle {0} in Dx12Contexts!", handleId);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
 
             if (contextData->createParams != nullptr)
             {
-                free(contextData->createParams);
+                TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::D3D12_DestroyParameters());
                 contextData->createParams = nullptr;
             }
 
@@ -174,11 +173,10 @@ bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device*
     // create new feature
     if (contextData->changeBackendCounter == 2)
     {
-        LOG_INFO("Creating new {} upscaler", State::Instance().newBackend);
-
+        LOG_INFO("Creating new {} upscaler", state.newBackend);
         contextData->feature.reset();
 
-        if (!GetFeature(State::Instance().newBackend, handleId, contextData->createParams, &contextData->feature))
+        if (!GetFeature(state.newBackend, handleId, contextData->createParams, &contextData->feature))
         {
             LOG_ERROR("Upscaler can't created");
             return false;
@@ -196,45 +194,47 @@ bool FeatureProvider_Dx12::ChangeFeature(std::string upscalerName, ID3D12Device*
 
         if (!initResult)
         {
-            LOG_ERROR("init failed with {0} feature", State::Instance().newBackend);
+            LOG_ERROR("init failed with {0} feature", state.newBackend);
 
-            if (State::Instance().newBackend != "dlssd")
+            if (state.newBackend != "dlssd")
             {
-                if (Config::Instance()->Dx12Upscaler == "dlss")
-                    State::Instance().newBackend = "xess";
+                if (cfg.Dx12Upscaler == "dlss")
+                    state.newBackend = "xess";
                 else
-                    State::Instance().newBackend = "fsr21";
+                    state.newBackend = "fsr21";
             }
             else
             {
                 // Retry DLSSD
-                State::Instance().newBackend = "dlssd";
+                state.newBackend = "dlssd";
             }
 
-            State::Instance().changeBackend[handleId] = true;
+            state.changeBackend[handleId] = true;
             return NVSDK_NGX_Result_Success;
         }
         else
         {
-            LOG_INFO("init successful for {0}, upscaler changed", State::Instance().newBackend);
+            LOG_INFO("init successful for {0}, upscaler changed", state.newBackend);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
         }
 
-        // if opti nvparam release it
+        // If this is an OptiScaler fake NVNGX param table, delete it
         int optiParam = 0;
+
         if (contextData->createParams->Get("OptiScaler", &optiParam) == NVSDK_NGX_Result_Success && optiParam == 1)
         {
-            free(contextData->createParams);
+            TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::D3D12_DestroyParameters());
             contextData->createParams = nullptr;
         }
     }
 
     // if initial feature can't be inited
-    State::Instance().currentFeature = contextData->feature.get();
-    if (State::Instance().currentFG != nullptr && State::Instance().activeFgInput == FGInput::Upscaler)
-        State::Instance().currentFG->UpdateTarget();
+    state.currentFeature = contextData->feature.get();
+
+    if (state.currentFG != nullptr && state.activeFgInput == FGInput::Upscaler)
+        state.currentFG->UpdateTarget();
 
     return true;
 }

--- a/OptiScaler/upscalers/FeatureProvider_Dx12.h
+++ b/OptiScaler/upscalers/FeatureProvider_Dx12.h
@@ -1,17 +1,23 @@
 #pragma once
-
 #include "SysUtils.h"
-
 #include "IFeature_Dx12.h"
-
 #include <inputs/NVNGX_DLSS.h>
 
 class FeatureProvider_Dx12
 {
   public:
-    static bool GetFeature(std::string upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
-                           std::unique_ptr<IFeature_Dx12>* feature);
 
-    static bool ChangeFeature(std::string upscalerName, ID3D12Device* device, ID3D12GraphicsCommandList* cmdList,
-                              UINT handleId, NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx12>* contextData);
+    static bool GetFeature(
+        std::string_view upscalerName, 
+        UINT handleId, 
+        NVSDK_NGX_Parameter* parameters,
+        std::unique_ptr<IFeature_Dx12>* feature);
+
+    static bool ChangeFeature(
+        std::string_view upscalerName, 
+        ID3D12Device* device, 
+        ID3D12GraphicsCommandList* cmdList,
+        UINT handleId, 
+        NVSDK_NGX_Parameter* parameters, 
+        ContextData<IFeature_Dx12>* contextData);
 };

--- a/OptiScaler/upscalers/FeatureProvider_Dx12.h
+++ b/OptiScaler/upscalers/FeatureProvider_Dx12.h
@@ -6,18 +6,9 @@
 class FeatureProvider_Dx12
 {
   public:
+    static bool GetFeature(std::string_view upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
+                           std::unique_ptr<IFeature_Dx12>* feature);
 
-    static bool GetFeature(
-        std::string_view upscalerName, 
-        UINT handleId, 
-        NVSDK_NGX_Parameter* parameters,
-        std::unique_ptr<IFeature_Dx12>* feature);
-
-    static bool ChangeFeature(
-        std::string_view upscalerName, 
-        ID3D12Device* device, 
-        ID3D12GraphicsCommandList* cmdList,
-        UINT handleId, 
-        NVSDK_NGX_Parameter* parameters, 
-        ContextData<IFeature_Dx12>* contextData);
+    static bool ChangeFeature(std::string_view upscalerName, ID3D12Device* device, ID3D12GraphicsCommandList* cmdList,
+                              UINT handleId, NVSDK_NGX_Parameter* parameters, ContextData<IFeature_Dx12>* contextData);
 };

--- a/OptiScaler/upscalers/FeatureProvider_Vk.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Vk.cpp
@@ -110,8 +110,7 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
     State& state = State::Instance();
     Config& cfg = *Config::Instance();
 
-    if (state.newBackend == "" ||
-        (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
+    if (state.newBackend == "" || (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
         state.newBackend = cfg.VulkanUpscaler.value_or_default();
 
     contextData->changeBackendCounter++;

--- a/OptiScaler/upscalers/FeatureProvider_Vk.cpp
+++ b/OptiScaler/upscalers/FeatureProvider_Vk.cpp
@@ -18,6 +18,9 @@
 bool FeatureProvider_Vk::GetFeature(std::string upscalerName, UINT handleId, NVSDK_NGX_Parameter* parameters,
                                     std::unique_ptr<IFeature_Vk>* feature)
 {
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
+
     do
     {
         if (upscalerName == "xess")
@@ -51,14 +54,14 @@ bool FeatureProvider_Vk::GetFeature(std::string upscalerName, UINT handleId, NVS
             break;
         }
 
-        if (Config::Instance()->DLSSEnabled.value_or_default())
+        if (cfg.DLSSEnabled.value_or_default())
         {
-            if (upscalerName == "dlss" && State::Instance().NVNGX_DLSS_Path.has_value())
+            if (upscalerName == "dlss" && state.NVNGX_DLSS_Path.has_value())
             {
                 *feature = std::make_unique<DLSSFeatureVk>(handleId, parameters);
                 break;
             }
-            else if (upscalerName == "dlssd" && State::Instance().NVNGX_DLSSD_Path.has_value())
+            else if (upscalerName == "dlssd" && state.NVNGX_DLSSD_Path.has_value())
             {
                 *feature = std::make_unique<DLSSDFeatureVk>(handleId, parameters);
                 break;
@@ -83,7 +86,7 @@ bool FeatureProvider_Vk::GetFeature(std::string upscalerName, UINT handleId, NVS
     }
     else
     {
-        Config::Instance()->VulkanUpscaler = upscalerName;
+        cfg.VulkanUpscaler = upscalerName;
     }
 
     auto result = (*feature)->ModuleLoaded();
@@ -93,7 +96,7 @@ bool FeatureProvider_Vk::GetFeature(std::string upscalerName, UINT handleId, NVS
         if (upscalerName == "dlssd")
             upscalerName = "dlss";
 
-        Config::Instance()->VulkanUpscaler = upscalerName;
+        cfg.VulkanUpscaler = upscalerName;
     }
 
     return result;
@@ -104,9 +107,12 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
                                        PFN_vkGetDeviceProcAddr gdpa, UINT handleId, NVSDK_NGX_Parameter* parameters,
                                        ContextData<IFeature_Vk>* contextData)
 {
-    if (State::Instance().newBackend == "" ||
-        (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
-        State::Instance().newBackend = Config::Instance()->VulkanUpscaler.value_or_default();
+    State& state = State::Instance();
+    Config& cfg = *Config::Instance();
+
+    if (state.newBackend == "" ||
+        (!cfg.DLSSEnabled.value_or_default() && state.newBackend == "dlss"))
+        state.newBackend = cfg.VulkanUpscaler.value_or_default();
 
     contextData->changeBackendCounter++;
 
@@ -117,15 +123,14 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
     {
         if (contextData->feature != nullptr)
         {
-            LOG_INFO("changing backend to {0}", State::Instance().newBackend);
+            LOG_INFO("changing backend to {0}", state.newBackend);
 
-            auto dc = contextData->feature.get();
+            auto* dc = contextData->feature.get();
+            // Use given params if using DLSS passthrough
+            const std::string_view backend = state.newBackend;
+            const bool isPassthrough = backend == "dlssd" || backend == "dlss";
 
-            if (State::Instance().newBackend != "dlssd" && State::Instance().newBackend != "dlss")
-                contextData->createParams = GetNGXParameters("OptiVk");
-            else
-                contextData->createParams = parameters;
-
+            contextData->createParams = isPassthrough ? parameters : GetNGXParameters("OptiVk", false);
             contextData->createParams->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, dc->GetFeatureFlags());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Width, dc->RenderWidth());
             contextData->createParams->Set(NVSDK_NGX_Parameter_Height, dc->RenderHeight());
@@ -149,12 +154,12 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
         {
             LOG_ERROR("can't find handle {0} in VkContexts!", handleId);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
 
             if (contextData->createParams != nullptr)
             {
-                free(contextData->createParams);
+                TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::VULKAN_DestroyParameters());
                 contextData->createParams = nullptr;
             }
 
@@ -166,11 +171,11 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
 
     if (contextData->changeBackendCounter == 2)
     {
-        LOG_INFO("Creating new {} upscaler", State::Instance().newBackend);
+        LOG_INFO("Creating new {} upscaler", state.newBackend);
 
         contextData->feature.reset();
 
-        if (!GetFeature(State::Instance().newBackend, handleId, contextData->createParams, &contextData->feature))
+        if (!GetFeature(state.newBackend, handleId, contextData->createParams, &contextData->feature))
         {
             LOG_ERROR("Upscaler can't created");
             return false;
@@ -193,47 +198,48 @@ bool FeatureProvider_Vk::ChangeFeature(std::string upscalerName, VkInstance inst
 
         if (!initResult || !contextData->feature->ModuleLoaded())
         {
-            LOG_ERROR("init failed with {0} feature", State::Instance().newBackend);
+            LOG_ERROR("init failed with {0} feature", state.newBackend);
 
-            if (State::Instance().newBackend != "dlssd")
+            if (state.newBackend != "dlssd")
             {
-                if (Config::Instance()->VulkanUpscaler == "dlss")
+                if (cfg.VulkanUpscaler == "dlss")
                 {
-                    State::Instance().newBackend = "xess";
+                    state.newBackend = "xess";
                 }
                 else
                 {
-                    State::Instance().newBackend = "fsr21";
+                    state.newBackend = "fsr21";
                 }
             }
             else
             {
                 // Retry DLSSD
-                State::Instance().newBackend = "dlssd";
+                state.newBackend = "dlssd";
             }
 
-            State::Instance().changeBackend[handleId] = true;
+            state.changeBackend[handleId] = true;
             return NVSDK_NGX_Result_Success;
         }
         else
         {
-            LOG_INFO("init successful for {0}, upscaler changed", State::Instance().newBackend);
+            LOG_INFO("init successful for {0}, upscaler changed", state.newBackend);
 
-            State::Instance().newBackend = "";
-            State::Instance().changeBackend[handleId] = false;
+            state.newBackend = "";
+            state.changeBackend[handleId] = false;
         }
 
-        // if opti nvparam release it
+        // If this is an OptiScaler fake NVNGX param table, delete it
         int optiParam = 0;
+
         if (contextData->createParams->Get("OptiScaler", &optiParam) == NVSDK_NGX_Result_Success && optiParam == 1)
         {
-            free(contextData->createParams);
+            TryDestroyNGXParameters(contextData->createParams, NVNGXProxy::VULKAN_DestroyParameters());
             contextData->createParams = nullptr;
         }
     }
 
     // if initial feature can't be inited
-    State::Instance().currentFeature = contextData->feature.get();
+    state.currentFeature = contextData->feature.get();
 
     return true;
 }

--- a/OptiScaler/upscalers/IFeature.cpp
+++ b/OptiScaler/upscalers/IFeature.cpp
@@ -169,7 +169,7 @@ bool IFeature::SetInitParameters(NVSDK_NGX_Parameter* InParameters)
     return false;
 }
 
-void IFeature::GetRenderResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight)
+void IFeature::GetRenderResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight)
 {
     if (InParameters->Get(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width, OutWidth) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/IFeature.cpp
+++ b/OptiScaler/upscalers/IFeature.cpp
@@ -169,7 +169,8 @@ bool IFeature::SetInitParameters(NVSDK_NGX_Parameter* InParameters)
     return false;
 }
 
-void IFeature::GetRenderResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight)
+void IFeature::GetRenderResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth,
+                                   unsigned int* OutHeight)
 {
     if (InParameters->Get(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width, OutWidth) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/IFeature.h
+++ b/OptiScaler/upscalers/IFeature.h
@@ -78,7 +78,7 @@ class IFeature
 
     void SetHandle(unsigned int InHandleId);
     bool SetInitParameters(NVSDK_NGX_Parameter* InParameters);
-    void GetRenderResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight);
+    void GetRenderResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight);
     void GetDynamicOutputResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height);
     float GetSharpness(const NVSDK_NGX_Parameter* InParameters);
 

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
@@ -522,7 +522,8 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
     else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
     {
         const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+        params.cameraFovAngleVertical =
+            GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
     }
     else
         params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
@@ -1,8 +1,10 @@
 #include <pch.h>
 #include <Config.h>
 #include <Util.h>
-
+#include "MathUtils.h"
 #include "FSR2Feature_Dx11.h"
+
+using namespace OptiMath;
 
 #define ASSIGN_DESC(dest, src)                                                                                         \
     dest.Width = src.Width;                                                                                            \
@@ -244,8 +246,12 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
     if (!IsInited())
         return false;
 
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
+
     if (!RCAS->IsInit())
-        Config::Instance()->RcasEnabled.set_volatile_value(false);
+        cfg.RcasEnabled.set_volatile_value(false);
 
     ID3D11ShaderResourceView* restoreSRVs[D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT] = {};
     ID3D11SamplerState* restoreSamplerStates[D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT] = {};
@@ -502,23 +508,24 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
 
     if (DepthInverted())
     {
-        params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+        params.cameraFar = cfg.FsrCameraNear.value_or_default();
+        params.cameraNear = cfg.FsrCameraFar.value_or_default();
     }
     else
     {
-        params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+        params.cameraFar = cfg.FsrCameraFar.value_or_default();
+        params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    if (Config::Instance()->FsrVerticalFov.has_value())
-        params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-    else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-        params.cameraFovAngleVertical =
-            2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                        (float) DisplayHeight() * (float) DisplayWidth());
+    if (cfg.FsrVerticalFov.has_value())
+        params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+    else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+    {
+        const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+    }
     else
-        params.cameraFovAngleVertical = 1.0471975511966f;
+        params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
     if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
@@ -1,7 +1,9 @@
 #include <pch.h>
 #include <Config.h>
-
+#include "MathUtils.h"
 #include "FSR2Feature_Dx11On12.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureDx11on12::Init(ID3D11Device* InDevice, ID3D11DeviceContext* InContext,
                                NVSDK_NGX_Parameter* InParameters)
@@ -21,6 +23,9 @@ bool FSR2FeatureDx11on12::Init(ID3D11Device* InDevice, ID3D11DeviceContext* InCo
 bool FSR2FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_Parameter* InParameters)
 {
     LOG_FUNC();
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!_baseInit)
     {
@@ -287,14 +292,15 @@ bool FSR2FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_N
             params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
         }
 
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
         if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
                 NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
@@ -297,7 +297,8 @@ bool FSR2FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_N
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+            params.cameraFovAngleVertical =
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
         }
         else
             params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
@@ -362,7 +362,8 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+            params.cameraFovAngleVertical =
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
         }
         else
             params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
@@ -1,7 +1,9 @@
 #include <pch.h>
 #include <Config.h>
-
 #include "FSR2Feature_Dx12.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureDx12::Init(ID3D12Device* InDevice, ID3D12GraphicsCommandList* InCommandList,
                            NVSDK_NGX_Parameter* InParameters)
@@ -34,6 +36,10 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 
     if (!IsInited())
         return false;
+
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -339,26 +345,27 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
             params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFar", &params.cameraFar) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_FarPlane, &params.cameraFar) != NVSDK_NGX_Result_Success)
     {
         if (DepthInverted())
-            params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraNear = cfg.FsrCameraFar.value_or_default();
         else
-            params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraFar = cfg.FsrCameraFar.value_or_default();
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFovAngleVertical", &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_CameraFovVertical, &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
     {
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
     }
 
     if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
@@ -1,9 +1,10 @@
 #include <pch.h>
 #include <Config.h>
-
 #include "FSR2Feature_Vk.h"
-
 #include "nvsdk_ngx_vk.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureVk::InitFSR2(const NVSDK_NGX_Parameter* InParameters)
 {
@@ -161,6 +162,9 @@ bool FSR2FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* I
 
     if (!IsInited())
         return false;
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -510,23 +514,24 @@ bool FSR2FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* I
 
     if (DepthInverted())
     {
-        params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+        params.cameraFar = cfg.FsrCameraNear.value_or_default();
+        params.cameraNear = cfg.FsrCameraFar.value_or_default();
     }
     else
     {
-        params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+        params.cameraFar = cfg.FsrCameraFar.value_or_default();
+        params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    if (Config::Instance()->FsrVerticalFov.has_value())
-        params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-    else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-        params.cameraFovAngleVertical =
-            2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                        (float) DisplayHeight() * (float) DisplayWidth());
+    if (cfg.FsrVerticalFov.has_value())
+        params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+    else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+    {
+        const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float) TargetHeight());
+    }
     else
-        params.cameraFovAngleVertical = 1.0471975511966f;
+        params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
     if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
@@ -528,7 +528,8 @@ bool FSR2FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* I
     else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
     {
         const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float) TargetHeight());
+        params.cameraFovAngleVertical =
+            GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
     }
     else
         params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
@@ -299,7 +299,8 @@ bool FSR2FeatureDx11on12_212::Evaluate(ID3D11DeviceContext* InDeviceContext, NVS
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+            params.cameraFovAngleVertical =
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
         }
         else
             params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
@@ -1,7 +1,9 @@
 #include <pch.h>
 #include <Config.h>
-
 #include "FSR2Feature_Dx11On12_212.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureDx11on12_212::Init(ID3D11Device* InDevice, ID3D11DeviceContext* InContext,
                                    NVSDK_NGX_Parameter* InParameters)
@@ -21,6 +23,9 @@ bool FSR2FeatureDx11on12_212::Init(ID3D11Device* InDevice, ID3D11DeviceContext* 
 bool FSR2FeatureDx11on12_212::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_Parameter* InParameters)
 {
     LOG_FUNC();
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!_baseInit)
     {
@@ -280,23 +285,24 @@ bool FSR2FeatureDx11on12_212::Evaluate(ID3D11DeviceContext* InDeviceContext, NVS
 
         if (DepthInverted())
         {
-            params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-            params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraFar = cfg.FsrCameraNear.value_or_default();
+            params.cameraNear = cfg.FsrCameraFar.value_or_default();
         }
         else
         {
-            params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-            params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+            params.cameraFar = cfg.FsrCameraFar.value_or_default();
+            params.cameraNear = cfg.FsrCameraNear.value_or_default();
         }
 
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
         if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
                 NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
@@ -370,7 +370,8 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+            params.cameraFovAngleVertical =
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
         }
         else
             params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
@@ -1,7 +1,9 @@
 #include <pch.h>
 #include <Config.h>
-
 #include "FSR2Feature_Dx12_212.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureDx12_212::Init(ID3D12Device* InDevice, ID3D12GraphicsCommandList* InCommandList,
                                NVSDK_NGX_Parameter* InParameters)
@@ -34,6 +36,10 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
 
     if (!IsInited())
         return false;
+
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -339,34 +345,35 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
 
     LOG_DEBUG("Sharpness: {0}", params.sharpness);
 
-    if (Config::Instance()->FsrCameraNear.has_value() || !Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraNear", &params.cameraNear) != NVSDK_NGX_Result_Success)
+    if (cfg.FsrCameraNear.has_value() || !cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_NearPlane, &params.cameraNear) != NVSDK_NGX_Result_Success)
     {
         if (DepthInverted())
-            params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
+            params.cameraFar = cfg.FsrCameraNear.value_or_default();
         else
-            params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+            params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFar", &params.cameraFar) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_FarPlane, &params.cameraFar) != NVSDK_NGX_Result_Success)
     {
         if (DepthInverted())
-            params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraNear = cfg.FsrCameraFar.value_or_default();
         else
-            params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraFar = cfg.FsrCameraFar.value_or_default();
     }
 
-    if (InParameters->Get("FSR.cameraFovAngleVertical", &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
+    if (ngxParams.Get(OptiKeys::FSR_CameraFovVertical, &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
     {
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
     }
 
     if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
@@ -551,7 +551,8 @@ bool FSR2FeatureVk212::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
     else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
     {
         const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+        params.cameraFovAngleVertical =
+            GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
     }
     else
         params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
@@ -1,9 +1,10 @@
 #include <pch.h>
 #include <Config.h>
-
 #include "FSR2Feature_Vk_212.h"
-
 #include "nvsdk_ngx_vk.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 bool FSR2FeatureVk212::InitFSR2(const NVSDK_NGX_Parameter* InParameters)
 {
@@ -184,6 +185,9 @@ bool FSR2FeatureVk212::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
 
     if (!IsInited())
         return false;
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -533,23 +537,24 @@ bool FSR2FeatureVk212::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
 
     if (DepthInverted())
     {
-        params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+        params.cameraFar = cfg.FsrCameraNear.value_or_default();
+        params.cameraNear = cfg.FsrCameraFar.value_or_default();
     }
     else
     {
-        params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+        params.cameraFar = cfg.FsrCameraFar.value_or_default();
+        params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    if (Config::Instance()->FsrVerticalFov.has_value())
-        params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-    else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-        params.cameraFovAngleVertical =
-            2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                        (float) DisplayHeight() * (float) DisplayWidth());
+    if (cfg.FsrVerticalFov.has_value())
+        params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+    else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+    {
+        const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+    }
     else
-        params.cameraFovAngleVertical = 1.0471975511966f;
+        params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
     if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr31/FSR31Feature.h
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature.h
@@ -46,45 +46,56 @@ class FSR31Feature : public virtual IFeature
         LOG_WARN("can't parse {0}", version_str);
     }
 
-    static inline uint32_t ffxResolveTypelessFormat(uint32_t format)
+    static inline void ffxResolveTypelessFormat(uint32_t& format)
     {
         switch (format)
         {
         case FFX_API_SURFACE_FORMAT_R10G10B10A2_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R10G10B10A2_UNORM;
+            format = FFX_API_SURFACE_FORMAT_R10G10B10A2_UNORM; 
+            return;
 
         case FFX_API_SURFACE_FORMAT_R32G32B32A32_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R32G32B32A32_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R32G32B32A32_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R16G16B16A16_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R16G16B16A16_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R16G16B16A16_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R32G32_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R32G32_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R32G32_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R8G8B8A8_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R8G8B8A8_UNORM;
+            format = FFX_API_SURFACE_FORMAT_R8G8B8A8_UNORM;
+            return;
 
         case FFX_API_SURFACE_FORMAT_B8G8R8A8_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_B8G8R8A8_UNORM;
+            format = FFX_API_SURFACE_FORMAT_B8G8R8A8_UNORM;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R16G16_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R16G16_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R16G16_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R32_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R32_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R32_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R8G8_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R8G8_UNORM;
+            format = FFX_API_SURFACE_FORMAT_R8G8_UNORM;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R16_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R16_FLOAT;
+            format = FFX_API_SURFACE_FORMAT_R16_FLOAT;
+            return;
 
         case FFX_API_SURFACE_FORMAT_R8_TYPELESS:
-            return FFX_API_SURFACE_FORMAT_R8_UNORM;
+            format = FFX_API_SURFACE_FORMAT_R8_UNORM;
+            return;
 
         default:
-            return format; // Already typed or unknown
+            return; // Already typed or unknown
         }
     }
 

--- a/OptiScaler/upscalers/fsr31/FSR31Feature.h
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature.h
@@ -51,7 +51,7 @@ class FSR31Feature : public virtual IFeature
         switch (format)
         {
         case FFX_API_SURFACE_FORMAT_R10G10B10A2_TYPELESS:
-            format = FFX_API_SURFACE_FORMAT_R10G10B10A2_UNORM; 
+            format = FFX_API_SURFACE_FORMAT_R10G10B10A2_UNORM;
             return;
 
         case FFX_API_SURFACE_FORMAT_R32G32B32A32_TYPELESS:

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
@@ -443,7 +443,8 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
     else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
     {
         const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+        params.cameraFovAngleVertical =
+            GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
     }
     else
         params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
@@ -1,8 +1,10 @@
 #include <pch.h>
 #include <Config.h>
 #include <Util.h>
-
 #include "FSR31Feature_Dx11.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 #define ASSIGN_DESC(dest, src)                                                                                         \
     dest.Width = src.Width;                                                                                            \
@@ -141,6 +143,10 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
 
     if (!IsInited())
         return false;
+
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -420,26 +426,27 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
 
     if (DepthInverted())
     {
-        params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+        params.cameraFar = cfg.FsrCameraNear.value_or_default();
+        params.cameraNear = cfg.FsrCameraFar.value_or_default();
     }
     else
     {
-        params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+        params.cameraFar = cfg.FsrCameraFar.value_or_default();
+        params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    State::Instance().lastFsrCameraFar = params.cameraFar;
-    State::Instance().lastFsrCameraNear = params.cameraNear;
+    state.lastFsrCameraFar = params.cameraFar;
+    state.lastFsrCameraNear = params.cameraNear;
 
-    if (Config::Instance()->FsrVerticalFov.has_value())
-        params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-    else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-        params.cameraFovAngleVertical =
-            2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                        (float) DisplayHeight() * (float) DisplayWidth());
+    if (cfg.FsrVerticalFov.has_value())
+        params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+    else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+    {
+        const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+    }
     else
-        params.cameraFovAngleVertical = 1.0471975511966f;
+        params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
     LOG_DEBUG("FsrVerticalFov: {0}", params.cameraFovAngleVertical);
 

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
@@ -345,7 +345,8 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
         else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
         {
             const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+            params.cameraFovAngleVertical =
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
         }
         else
             params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
@@ -1,10 +1,11 @@
 #include <pch.h>
 #include <Config.h>
 #include <Util.h>
-
 #include <proxies/FfxApi_Proxy.h>
-
 #include "FSR31Feature_Dx11On12.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 NVSDK_NGX_Parameter* FSR31FeatureDx11on12::SetParameters(NVSDK_NGX_Parameter* InParameters)
 {
@@ -44,6 +45,9 @@ bool FSR31FeatureDx11on12::Init(ID3D11Device* InDevice, ID3D11DeviceContext* InC
 bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_Parameter* InParameters)
 {
     LOG_FUNC();
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!_baseInit)
     {
@@ -297,13 +301,12 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
         // transparencyAndComposition and exposure might be unnecessary here
         if (Version().major >= 4)
         {
-            params.color.description.format = ffxResolveTypelessFormat(params.color.description.format);
-            params.depth.description.format = ffxResolveTypelessFormat(params.depth.description.format);
-            params.motionVectors.description.format = ffxResolveTypelessFormat(params.motionVectors.description.format);
-            params.exposure.description.format = ffxResolveTypelessFormat(params.exposure.description.format);
-            params.transparencyAndComposition.description.format =
-                ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
-            params.output.description.format = ffxResolveTypelessFormat(params.output.description.format);
+            ffxResolveTypelessFormat(params.color.description.format);
+            ffxResolveTypelessFormat(params.depth.description.format);
+            ffxResolveTypelessFormat(params.motionVectors.description.format);
+            ffxResolveTypelessFormat(params.exposure.description.format);
+            ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
+            ffxResolveTypelessFormat(params.output.description.format);
         }
 
         float MVScaleX = 1.0f;
@@ -325,26 +328,27 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
 
         if (DepthInverted())
         {
-            params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-            params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraFar = cfg.FsrCameraNear.value_or_default();
+            params.cameraNear = cfg.FsrCameraFar.value_or_default();
         }
         else
         {
-            params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-            params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+            params.cameraFar = cfg.FsrCameraFar.value_or_default();
+            params.cameraNear = cfg.FsrCameraNear.value_or_default();
         }
 
         State::Instance().lastFsrCameraFar = params.cameraFar;
         State::Instance().lastFsrCameraNear = params.cameraNear;
 
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-            params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+            params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
         if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
                 NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
@@ -1,10 +1,11 @@
 #include <pch.h>
 #include <Config.h>
 #include <Util.h>
-
 #include <proxies/FfxApi_Proxy.h>
-
 #include "FSR31Feature_Dx12.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 NVSDK_NGX_Parameter* FSR31FeatureDx12::SetParameters(NVSDK_NGX_Parameter* InParameters)
 {
@@ -57,6 +58,9 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
 
     if (!IsInited())
         return false;
+
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -360,13 +364,12 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
     // transparencyAndComposition and exposure might be unnecessary here
     if (Version().major >= 4)
     {
-        params.color.description.format = ffxResolveTypelessFormat(params.color.description.format);
-        params.depth.description.format = ffxResolveTypelessFormat(params.depth.description.format);
-        params.motionVectors.description.format = ffxResolveTypelessFormat(params.motionVectors.description.format);
-        params.exposure.description.format = ffxResolveTypelessFormat(params.exposure.description.format);
-        params.transparencyAndComposition.description.format =
-            ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
-        params.output.description.format = ffxResolveTypelessFormat(params.output.description.format);
+        ffxResolveTypelessFormat(params.color.description.format);
+        ffxResolveTypelessFormat(params.depth.description.format);
+        ffxResolveTypelessFormat(params.motionVectors.description.format);
+        ffxResolveTypelessFormat(params.exposure.description.format);
+        ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
+        ffxResolveTypelessFormat(params.output.description.format);
     }
 
     float MVScaleX = 1.0f;
@@ -401,22 +404,24 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
         InParameters->Get("FSR.cameraFar", &params.cameraFar) != NVSDK_NGX_Result_Success)
     {
         if (DepthInverted())
-            params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraNear = cfg.FsrCameraFar.value_or_default();
         else
-            params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
+            params.cameraFar = cfg.FsrCameraFar.value_or_default();
     }
 
-    if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||
-        InParameters->Get("FSR.cameraFovAngleVertical", &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
+    if (!cfg.FsrUseFsrInputValues.value_or_default() ||
+        ngxParams.Get(OptiKeys::FSR_CameraFovVertical, &params.cameraFovAngleVertical) != NVSDK_NGX_Result_Success)
     {
-        if (Config::Instance()->FsrVerticalFov.has_value())
-            params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-        else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
+        if (cfg.FsrVerticalFov.has_value())
+            params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+        else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+        {
+            const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
             params.cameraFovAngleVertical =
-                2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                            (float) TargetHeight() * (float) TargetWidth());
+                GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
+        }
         else
-            params.cameraFovAngleVertical = 1.0471975511966f;
+            params.cameraFovAngleVertical = GetRadiansFromDeg(60);
     }
 
     if (!Config::Instance()->FsrUseFsrInputValues.value_or_default() ||

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
@@ -667,7 +667,8 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
     else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
     {
         const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
-        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+        params.cameraFovAngleVertical =
+            GetVerticalFovFromHorizontal(hFovRad, (float) TargetWidth(), (float) TargetHeight());
     }
     else
         params.cameraFovAngleVertical = GetRadiansFromDeg(60);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
@@ -3,8 +3,10 @@
 #include <Util.h>
 #include <proxies/FfxApi_Proxy.h>
 #include "FSR31Feature_Vk.h"
-
 #include "nvsdk_ngx_vk.h"
+#include "MathUtils.h"
+
+using namespace OptiMath;
 
 static inline uint32_t ffxApiGetSurfaceFormatVKLocal(VkFormat fmt)
 {
@@ -319,6 +321,10 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
 
     if (!IsInited())
         return false;
+
+    auto& state = State::Instance();
+    auto& cfg = *Config::Instance();
+    const auto& ngxParams = *InParameters;
 
     if (!RCAS->IsInit())
         Config::Instance()->RcasEnabled.set_volatile_value(false);
@@ -647,23 +653,24 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
 
     if (DepthInverted())
     {
-        params.cameraFar = Config::Instance()->FsrCameraNear.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraFar.value_or_default();
+        params.cameraFar = cfg.FsrCameraNear.value_or_default();
+        params.cameraNear = cfg.FsrCameraFar.value_or_default();
     }
     else
     {
-        params.cameraFar = Config::Instance()->FsrCameraFar.value_or_default();
-        params.cameraNear = Config::Instance()->FsrCameraNear.value_or_default();
+        params.cameraFar = cfg.FsrCameraFar.value_or_default();
+        params.cameraNear = cfg.FsrCameraNear.value_or_default();
     }
 
-    if (Config::Instance()->FsrVerticalFov.has_value())
-        params.cameraFovAngleVertical = Config::Instance()->FsrVerticalFov.value() * 0.0174532925199433f;
-    else if (Config::Instance()->FsrHorizontalFov.value_or_default() > 0.0f)
-        params.cameraFovAngleVertical =
-            2.0f * atan((tan(Config::Instance()->FsrHorizontalFov.value() * 0.0174532925199433f) * 0.5f) /
-                        (float) DisplayHeight() * (float) DisplayWidth());
+    if (cfg.FsrVerticalFov.has_value())
+        params.cameraFovAngleVertical = GetRadiansFromDeg(cfg.FsrVerticalFov.value());
+    else if (cfg.FsrHorizontalFov.value_or_default() > 0.0f)
+    {
+        const float hFovRad = GetRadiansFromDeg(cfg.FsrHorizontalFov.value());
+        params.cameraFovAngleVertical = GetVerticalFovFromHorizontal(hFovRad, (float)TargetWidth(), (float)TargetHeight());
+    }
     else
-        params.cameraFovAngleVertical = 1.0471975511966f;
+        params.cameraFovAngleVertical = GetRadiansFromDeg(60);
 
     if (InParameters->Get(NVSDK_NGX_Parameter_FrameTimeDeltaInMsec, &params.frameTimeDelta) !=
             NVSDK_NGX_Result_Success ||

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_VkOn12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_VkOn12.cpp
@@ -289,13 +289,12 @@ bool FSR31FeatureVkOn12::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Paramet
         // For FSR 4 - resolve typeless formats
         if (Version().major >= 4)
         {
-            params.color.description.format = ffxResolveTypelessFormat(params.color.description.format);
-            params.depth.description.format = ffxResolveTypelessFormat(params.depth.description.format);
-            params.motionVectors.description.format = ffxResolveTypelessFormat(params.motionVectors.description.format);
-            params.exposure.description.format = ffxResolveTypelessFormat(params.exposure.description.format);
-            params.transparencyAndComposition.description.format =
-                ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
-            params.output.description.format = ffxResolveTypelessFormat(params.output.description.format);
+            ffxResolveTypelessFormat(params.color.description.format);
+            ffxResolveTypelessFormat(params.depth.description.format);
+            ffxResolveTypelessFormat(params.motionVectors.description.format);
+            ffxResolveTypelessFormat(params.exposure.description.format);
+            ffxResolveTypelessFormat(params.transparencyAndComposition.description.format);
+            ffxResolveTypelessFormat(params.output.description.format);
         }
 
         float MVScaleX = 1.0f;


### PR DESCRIPTION
This PR includes fixes for a memory corruption risk in DLSS inputs, corrects a math error in the configurable FSR FOV conversion, and a couple housekeeping items.

* **Fixed NGX Memory Management:** Replaced unsafe C-style `free()` calls on `NVSDK_NGX_Parameter` objects with a new tagging system. This ensures that memory owned by the NGX API or internal trackers is deallocated correctly, preventing potential heap corruption and crashes.

* **Corrected FSR FOV Conversion:** Fixed the math for (all five) users manually setting a custom Horizontal FOV. It now correctly scales to Vertical FOV for the upscaler using the proper trigonometric formula.

* **DLSS DX12 Input Refactor:** In the process of investigating the memory management issue, I ended up cleaning up `CreateFeature` and `EvaluateFeature` and adding some inline documentatioin.

* **Code Housekeeping:** Started moving string identifiers into a dedicated `OptiTexts.h` header to replace error-prone raw strings literals and enable IntelliSense support. Usages for these identifiers haven't been replaced, but I think it would be a good idea to start using them going forward.