### PR TITLE
Native vulkan fixes

### DIFF
--- a/OptiScaler/hooks/Reflex_Hooks.cpp
+++ b/OptiScaler/hooks/Reflex_Hooks.cpp
@@ -383,6 +383,7 @@ NvAPI_Status ReflexHooks::hkNvAPI_Vulkan_SetLatencyMarker(HANDLE vkDevice,
 #endif
 
     _updatesWithoutMarker = 0;
+    State::Instance().reflexFrameId = pSetLatencyMarkerParams->frameID;
 
     return o_NvAPI_Vulkan_SetLatencyMarker(vkDevice, pSetLatencyMarkerParams);
 }
@@ -532,41 +533,42 @@ bool ReflexHooks::updateTimingData()
         UPDATE_TIMING_ENTRY(osRenderQueue, OsRenderQueue)
         UPDATE_TIMING_ENTRY(gpuRender, GpuRender)
 
+        if (frameReport.frameID != 0)
+            State::Instance().reflexFrameId = frameReport.frameID;
+
         return true;
     };
 
-    if (_lastSleepDev)
+    if (_lastSleepDev && o_NvAPI_D3D_GetLatency)
     {
-        if (o_NvAPI_D3D_GetLatency)
+        // Not calling free on this but it's static so hopefully fine
+        static NV_LATENCY_RESULT_PARAMS* results = new NV_LATENCY_RESULT_PARAMS();
+        results->version = NV_LATENCY_RESULT_PARAMS_VER;
+
+        if (auto result = hkNvAPI_D3D_GetLatency(_lastSleepDev, results); result != NVAPI_OK)
         {
-            // Not calling free on this but it's static so hopefully fine
-            static NV_LATENCY_RESULT_PARAMS* results = new NV_LATENCY_RESULT_PARAMS();
-            results->version = NV_LATENCY_RESULT_PARAMS_VER;
-
-            if (auto result = hkNvAPI_D3D_GetLatency(_lastSleepDev, results); result != NVAPI_OK)
-            {
-                LOG_WARN("NvAPI_D3D_GetLatency failed: {}", magic_enum::enum_name(result));
-                return false;
-            }
-
-            // 64th element has the latest data
-            return processFrameReport(results->frameReport[63]);
+            LOG_WARN("NvAPI_D3D_GetLatency failed: {}", magic_enum::enum_name(result));
+            return false;
         }
-        else if (o_NvAPI_Vulkan_GetLatency)
+
+        // 64th element has the latest data
+        return processFrameReport(results->frameReport[63]);
+    }
+
+    if (_lastVkSleepDev && o_NvAPI_Vulkan_GetLatency)
+    {
+        // Not calling free on this but it's static so hopefully fine
+        static NV_VULKAN_LATENCY_RESULT_PARAMS* results = new NV_VULKAN_LATENCY_RESULT_PARAMS();
+        results->version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
+
+        if (auto result = hkNvAPI_Vulkan_GetLatency(_lastVkSleepDev, results); result != NVAPI_OK)
         {
-            // Not calling free on this but it's static so hopefully fine
-            static NV_VULKAN_LATENCY_RESULT_PARAMS* results = new NV_VULKAN_LATENCY_RESULT_PARAMS();
-            results->version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
-
-            if (auto result = hkNvAPI_Vulkan_GetLatency(_lastVkSleepDev, results); result != NVAPI_OK)
-            {
-                LOG_WARN("NvAPI_Vulkan_GetLatency failed: {}", magic_enum::enum_name(result));
-                return false;
-            }
-
-            // 64th element has the latest data
-            return processFrameReport(results->frameReport[63]);
+            LOG_WARN("NvAPI_Vulkan_GetLatency failed: {}", magic_enum::enum_name(result));
+            return false;
         }
+
+        // 64th element has the latest data
+        return processFrameReport(results->frameReport[63]);
     }
 
     return false;

--- a/OptiScaler/hooks/VulkanwDx12_Hooks.cpp
+++ b/OptiScaler/hooks/VulkanwDx12_Hooks.cpp
@@ -6223,17 +6223,11 @@ VkResult Vulkan_wDx12::hk_vkQueueSubmit(VkQueue queue, uint32_t submitCount, VkS
                 syncSubmitInfo.pSignalSemaphores = signals;
 
                 // move signal values to new submit
-                if (signalValues.size() > 0)
-                {
-                    syncTimelineInfo.signalSemaphoreValueCount =
-                        static_cast<uint32_t>(signalValues.size()) + signalCount;
-                    syncTimelineInfo.pSignalSemaphoreValues = signalValues.data();
-                }
-                else
-                {
-                    syncTimelineInfo.signalSemaphoreValueCount = signalCount;
-                    syncTimelineInfo.pSignalSemaphoreValues = nullptr;
-                }
+                for (uint32_t z = 0; z < signalCount; z++)
+                    signalValues.push_back(0);
+
+                syncTimelineInfo.signalSemaphoreValueCount = static_cast<uint32_t>(signalValues.size());
+                syncTimelineInfo.pSignalSemaphoreValues = signalValues.data();
 
                 // prepare new submit infos list
                 submitInfos.reserve(submitCount + 2);
@@ -6614,17 +6608,11 @@ VkResult Vulkan_wDx12::hk_vkQueueSubmit(VkQueue queue, uint32_t submitCount, con
                 syncSubmitInfo.pSignalSemaphores = signals;
 
                 // move signal values to new submit
-                if (signalValues.size() > 0)
-                {
-                    syncTimelineInfo.signalSemaphoreValueCount =
-                        static_cast<uint32_t>(signalValues.size()) + signalCount;
-                    syncTimelineInfo.pSignalSemaphoreValues = signalValues.data();
-                }
-                else
-                {
-                    syncTimelineInfo.signalSemaphoreValueCount = signalCount;
-                    syncTimelineInfo.pSignalSemaphoreValues = nullptr;
-                }
+                for (uint32_t z = 0; z < signalCount; z++)
+                    signalValues.push_back(0);
+
+                syncTimelineInfo.signalSemaphoreValueCount = static_cast<uint32_t>(signalValues.size());
+                syncTimelineInfo.pSignalSemaphoreValues = signalValues.data();
 
                 // prepare new submit infos list
                 finalSubmits.reserve(submitCount + 2);

--- a/OptiScaler/misc/IdentifyGpu.cpp
+++ b/OptiScaler/misc/IdentifyGpu.cpp
@@ -41,6 +41,8 @@ std::vector<GpuInformation> IdentifyGpu::checkGpuInfo()
 {
     auto localCachedInfo = std::vector<GpuInformation> {};
 
+    ScopedSkipSpoofing skipSpoofing {};
+
     DxgiProxy::Init();
 
     ComPtr<IDXGIFactory6> factory = nullptr;
@@ -71,10 +73,7 @@ std::vector<GpuInformation> IdentifyGpu::checkGpuInfo()
             continue;
         }
 
-        {
-            ScopedSkipSpoofing skipSpoofing {};
-            result = adapter->GetDesc1(&adapterDesc);
-        }
+        result = adapter->GetDesc1(&adapterDesc);
 
         if (result == S_OK)
         {
@@ -328,6 +327,8 @@ void IdentifyGpu::updateD3d12Capabilities(D3d12Proxy::PFN_D3D12CreateDevice o_D3
                 pD3D12CreateDevice = D3d12Proxy::D3D12CreateDevice_();
 
             // D3D12 device is needed to be able to query amdxc and check for vkd3d-proton
+            ScopedCreatingD3DDevice scopedCreating {};
+            ScopedSkipVulkanHooks skipVulkanHooks {};
             mutex.unlock(); // To avoid VK hooks, not ideal
             auto createResult =
                 pD3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(&gpuInfo.d3d12device));


### PR DESCRIPTION
Fixes gpu detection on native vulkan games, was grabbing the spoofed dxgi info ~~so ive added a check for getting vendorId from vulkan instead of dxgi before spoof~~ moved skip spoofing to pre dxgi init, also fixed reflex timing overlay not appearing, and fixed a crash with vk/w dx12

havent tested windows is fine yet but should work, game tested was NMS