### PR TITLE
Fix FG freeze/crash when Unity games render save thumbnails

### DIFF
--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -119,6 +119,13 @@ class State
     bool SCchanged = false;
     bool skipHeapCapture = false;
 
+    // Set when a save thumbnail upscaler (<=640x360) is created.
+    // Stays true through the entire thumbnail sequence (thumbnail create →
+    // main upscaler release → replacement upscaler create) to prevent
+    // FGchanged from being set during the save operation.
+    // Cleared when the replacement normal-res upscaler is created.
+    bool thumbnailSaveActive = false;
+
     bool FGcaptureResources = false;
     size_t FGcapturedResourceCount = 0;
     bool FGresetCapturedResources = false;

--- a/OptiScaler/framegen/ffx/FSRFG_Dx12.cpp
+++ b/OptiScaler/framegen/ffx/FSRFG_Dx12.cpp
@@ -758,7 +758,7 @@ void* FSRFG_Dx12::SwapchainContext()
 void FSRFG_Dx12::DestroyFGContext()
 {
     _frameCount = 1;
-    // _lastDispatchedFrame = 0;
+    _lastDispatchedFrame = 0;
     _version = {};
 
     LOG_DEBUG("");

--- a/OptiScaler/hooks/FG_Hooks.cpp
+++ b/OptiScaler/hooks/FG_Hooks.cpp
@@ -1020,6 +1020,19 @@ HRESULT FGHooks::FGPresent(IDXGISwapChain* This, UINT SyncInterval, UINT Flags,
             return o_FGSCPresent1((IDXGISwapChain1*) This, SyncInterval, Flags, pPresentParameters);
     }
 
+    // If FG is not active (e.g. deactivated during save thumbnail), bypass all FG processing
+    // to prevent deadlocks when the game captures a screenshot for the save file
+    auto fg = State::Instance().currentFG;
+    if (fg == nullptr || !fg->IsActive() || fg->IsPaused())
+    {
+        Hudfix_Dx12::PresentEnd();
+
+        if (pPresentParameters == nullptr)
+            return o_FGSCPresent(This, SyncInterval, Flags);
+        else
+            return o_FGSCPresent1((IDXGISwapChain1*) This, SyncInterval, Flags, pPresentParameters);
+    }
+
     auto willPresent = (Flags & DXGI_PRESENT_TEST) == 0;
 
     if (willPresent)
@@ -1043,7 +1056,7 @@ HRESULT FGHooks::FGPresent(IDXGISwapChain* This, UINT SyncInterval, UINT Flags,
         UpscalerTimeDx12::ReadUpscalingTime(State::Instance().currentCommandQueue);
     }
 
-    auto fg = State::Instance().currentFG;
+    // fg already declared above in early-exit bypass
     bool mutexUsed = false;
     if (willPresent && fg != nullptr && fg->IsActive() && !fg->IsPaused() &&
         Config::Instance()->FGUseMutexForSwapchain.value_or_default() && fg->Mutex.getOwner() != 2)

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -727,7 +727,33 @@ static NVSDK_NGX_Result TryCreateOptiFeature(ID3D12GraphicsCommandList* InCmdLis
 
     D3D12Hooks::SetRootSignatureTracking(true);
 
-    state.FGchanged = true;
+    // Don't trigger FG state change during save thumbnail sequences.
+    // Unity games (e.g. Fall of Avalon) render save thumbnails at tiny resolutions
+    // (320x180) which creates a temporary upscaler. The sequence is:
+    //   1. Thumbnail upscaler created (320x180)
+    //   2. Main upscaler released
+    //   3. Replacement normal-res upscaler created (3840x2160)
+    // We must suppress FGchanged for ALL THREE steps, not just step 1,
+    // otherwise the replacement upscaler triggers FG deactivation → freeze.
+    // The flag is set in step 1 and cleared in step 3.
+    if (feature != nullptr && feature->DisplayWidth() <= 640 && feature->DisplayHeight() <= 360)
+    {
+        LOG_INFO("Thumbnail feature ({}x{}), setting thumbnailSaveActive and skipping FGchanged",
+                 feature->DisplayWidth(), feature->DisplayHeight());
+        state.thumbnailSaveActive = true;
+    }
+    else if (state.thumbnailSaveActive)
+    {
+        LOG_INFO("Replacement upscaler created after thumbnail ({}x{}), skipping FGchanged, clearing thumbnailSaveActive",
+                 feature != nullptr ? feature->DisplayWidth() : 0,
+                 feature != nullptr ? feature->DisplayHeight() : 0);
+        state.thumbnailSaveActive = false;
+        // Don't set FGchanged — FG stays active throughout the save sequence
+    }
+    else
+    {
+        state.FGchanged = true;
+    }
 
     return NVSDK_NGX_Result_Success;
 }
@@ -816,17 +842,54 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
 {
     LOG_FUNC();
 
+    State& state = State::Instance();
+
     if (!InHandle)
         return NVSDK_NGX_Result_Success;
 
     auto handleId = InHandle->Id;
-    State::Instance().FGchanged = true;
+
+    // Check if we're in a save thumbnail sequence. If the thumbnailSaveActive
+    // flag is set, or a thumbnail feature still exists in contexts, skip FG cleanup.
+    // The flag covers the case where the thumbnail was already released but the
+    // replacement upscaler hasn't been created yet.
+    bool skipFgCleanup = state.thumbnailSaveActive;
+    if (!skipFgCleanup)
+    {
+        for (auto& [id, ctx] : Dx12Contexts)
+        {
+            auto* f = ctx.feature.get();
+            if (f != nullptr && f->DisplayWidth() <= 640 && f->DisplayHeight() <= 360)
+            {
+                skipFgCleanup = true;
+                LOG_INFO("Thumbnail feature found ({}x{}) during release of {}, skipping FG cleanup",
+                         f->DisplayWidth(), f->DisplayHeight(), handleId);
+                break;
+            }
+        }
+    }
+    else
+    {
+        LOG_INFO("thumbnailSaveActive flag set during release of {}, skipping FG cleanup", handleId);
+    }
+
+    if (!skipFgCleanup)
+        state.FGchanged = true;
 
     // Clean up framegen
-    if (State::Instance().currentFG != nullptr && State::Instance().activeFgInput == FGInput::Upscaler)
+    // Only deactivate FG instead of destroying the context.
+    // Destroying causes deadlocks in games that render save thumbnails at
+    // reduced resolution (e.g. Unity games like Fall of Avalon).
+    // The FG context is preserved and reactivated when the upscaler is recreated
+    // at normal resolution. Full destruction still happens on shutdown or swapchain change.
+    // During a save thumbnail sequence, skip FG cleanup entirely.
+    if (state.currentFG != nullptr && state.activeFgInput == FGInput::Upscaler && !skipFgCleanup)
     {
-        State::Instance().currentFG->DestroyFGContext();
-        State::Instance().ClearCapturedHudlesses = true;
+        if (state.currentFG->IsActive())
+            state.currentFG->Deactivate();
+
+        state.FGchanged = true;
+        state.ClearCapturedHudlesses = true;
         UpscalerInputsDx12::Reset();
     }
 

--- a/OptiScaler/misc/Quirks.h
+++ b/OptiScaler/misc/Quirks.h
@@ -417,6 +417,11 @@ static const QuirkEntry quirkTable[] = {
     QUIRK_ENTRY_UE(ghostrunner2, GameQuirk::ForceUnrealEngine),
     QUIRK_ENTRY("soulstice.exe", GameQuirk::ForceUnrealEngine, GameQuirk::ForceAutoExposure),
 
+    // Fall of Avalon (Unity)
+    // Save thumbnails cause resolution drop (320x180) which destroys/recreates FG context
+    // resulting in broken frame tracking and crash
+    QUIRK_ENTRY("fall of avalon.exe", GameQuirk::FastFeatureReset, GameQuirk::ForceAutoExposure),
+
     // VULKAN
     // ------
 


### PR DESCRIPTION
## Problem

Unity games (e.g. **Tainted Grail: Fall of Avalon**) render save thumbnails at tiny resolutions (320×180, render 144×81). This triggers FSR Frame Generation to deactivate/destroy its context, causing FSR FG's swapchain frame pacing to **deadlock permanently** — the game freezes every time the player saves with FG enabled.

## Root Cause

The save triggers a 3-step upscaler lifecycle change:
1. **Thumbnail upscaler created** (320×180) → old code set `FGchanged`
2. **Main upscaler released** (3840×2160) → old code called `DestroyFGContext()`
3. **Replacement upscaler created** (3840×2160) → old code set `FGchanged`

Any FG state change during active rendering causes FSR FG's internal swapchain frame pacing to deadlock. This is in AMD's FSR FG library code and cannot be fixed from outside.

## Fix

Add a `thumbnailSaveActive` flag that spans the **entire** 3-step sequence:

| Step | Resolution | What happens |
|------|-----------|--------------|
| 1. Thumbnail create | 320×180 | Flag set, `FGchanged` suppressed |
| 2. Main upscaler release | — | Flag checked, FG cleanup skipped |
| 3. Replacement create | 3840×2160 | Flag checked, `FGchanged` suppressed, flag cleared |

FG stays active through the entire save. The 1-2 frames of wrong-resolution FG dispatch are invisible (tiny render-to-texture operation). When normal resolution returns, FG continues without interruption.

## Additional Changes

- **Quirks.h**: Added `fall of avalon.exe` entry with `FastFeatureReset` + `ForceAutoExposure`
- **FSRFG_Dx12.cpp**: Reset `_lastDispatchedFrame = 0` in `DestroyFGContext()` (was commented out, fixes broken frame tracking after context recreation)
- **FG_Hooks.cpp**: Bypass FG Present processing when FG is inactive/paused (safety net — prevents mutex deadlocks if FG is deactivated through other paths)
- **NVNGX_DLSS_Dx12.cpp**: Use `Deactivate()` instead of `DestroyFGContext()` in `ReleaseFeature` for upscaler lifecycle changes (preserves FG context for reuse)

## Testing

Tested with:
- **Game**: Tainted Grail: Fall of Avalon (Unity 6000.0.64f1, v1.22.131)
- **GPU**: AMD Radeon Pro W7900 (RADV NAVI31)
- **OS**: Windows 10 via Wine/Proton
- **Config**: FSR 3.1 upscaling + FSR 3 Frame Generation, FGInput=upscaler

✅ Save with FG enabled — no freeze
✅ Multiple saves in succession — stable
✅ Normal gameplay with FG — no regressions

## Known Issue (pre-existing, not introduced by this PR)

Switching upscalers while FG is active causes a freeze. This is a **pre-existing bug** in OptiScaler — the original `DestroyFGContext()` in `ChangeFeature` also freezes. Workaround: disable FG → switch upscaler → re-enable FG. This is tracked separately.