### PR TITLE
Fix dllmain.cpp compile error

### DIFF
--- a/OptiScaler/dllmain.cpp
+++ b/OptiScaler/dllmain.cpp
@@ -2056,13 +2056,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
             FSR3FG::HookFSR3FGExeInputs();
         }
 
-        if (State::Instance().activeFgInput == FGInput::Upscaler &&
-            State::Instance().GameEngine == GameEngineType::Unity && !Config::Instance()->FGResourceFlip.has_value())
-        {
-            LOG_WARN("Unity detected with Upscaler input, but FGResourceFlip is not set. Enabling it");
-            Config::Instance()->FGResourceFlip.set_volatile_value(true);
-        }
-
         for (size_t i = 0; i < 300; i++)
         {
             State::Instance().frameTimes.push_back(0.0f);


### PR DESCRIPTION
Quick fix for dllmain.cpp file compile error, reverted changes for commit "https://github.com/optiscaler/OptiScaler/commit/3ffc972447c413c9cd144b0fdd745700558d1628"

```
D:\a\OptiScaler\OptiScaler\OptiScaler\dllmain.cpp(2060,31): error C2039: 'GameEngine': is not a member of 'State' [D:\a\OptiScaler\OptiScaler\OptiScaler\OptiScaler.vcxproj]
  (compiling source file '/dllmain.cpp')
      D:\a\OptiScaler\OptiScaler\OptiScaler\State.h(71,7):
      see declaration of 'State'
  
D:\a\OptiScaler\OptiScaler\OptiScaler\dllmain.cpp(2060,45): error C2653: 'GameEngineType': is not a class or namespace name [D:\a\OptiScaler\OptiScaler\OptiScaler\OptiScaler.vcxproj]
  (compiling source file '/dllmain.cpp')
  
D:\a\OptiScaler\OptiScaler\OptiScaler\dllmain.cpp(2060,61): error C2065: 'Unity': undeclared identifier [D:\a\OptiScaler\OptiScaler\OptiScaler\OptiScaler.vcxproj]
  (compiling source file '/dllmain.cpp')

Util.cpp
version_check.cpp
XeSS_Debug.cpp
XeSS_Dx12.cpp
Error: Process completed with exit code 1.
```