### PR TITLE
DLSS Enabler static-embedding compatibility 

### DIFF
--- a/OptiScaler.sln
+++ b/OptiScaler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32602.215
+# Visual Studio Version 18
+VisualStudioVersion = 18.8.11904.113 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OptiScaler", "OptiScaler\OptiScaler.vcxproj", "{8D2B73FB-EECD-45CE-B8E5-335610462F58}"
 EndProject
@@ -13,6 +13,8 @@ Global
 		Release|x86 = Release|x86
 		ReleaseDebug|x64 = ReleaseDebug|x64
 		ReleaseDebug|x86 = ReleaseDebug|x86
+		ReleaseStatic|x64 = ReleaseStatic|x64
+		ReleaseStatic|x86 = ReleaseStatic|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.Debug|x64.ActiveCfg = Debug|x64
@@ -27,6 +29,10 @@ Global
 		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseDebug|x64.Build.0 = ReleaseDebug|x64
 		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseDebug|x86.ActiveCfg = ReleaseDebug|Win32
 		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseDebug|x86.Build.0 = ReleaseDebug|Win32
+		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseStatic|x64.ActiveCfg = ReleaseStatic|x64
+		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseStatic|x64.Build.0 = ReleaseStatic|x64
+		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseStatic|x86.ActiveCfg = ReleaseStatic|Win32
+		{8D2B73FB-EECD-45CE-B8E5-335610462F58}.ReleaseStatic|x86.Build.0 = ReleaseStatic|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -13,6 +13,14 @@
       <Configuration>ReleaseDebug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseStatic|Win32">
+      <Configuration>ReleaseStatic</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseStatic|x64">
+      <Configuration>ReleaseStatic</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -47,6 +55,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -62,6 +77,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -85,6 +107,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -92,6 +117,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'" Label="PropertySheets">
@@ -106,6 +134,10 @@
     <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)\external\nvngx_dlss_sdk;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)\external\vulkan\include;$(SolutionDir)\external\xess\inc\xess;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)\external\xess\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">
+    <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)\external\nvngx_dlss_sdk;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)\external\vulkan\include;$(SolutionDir)\external\xess\inc\xess;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)\external\xess\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|Win32'">
     <IncludePath>$(SolutionDir)external\simpleini;$(SolutionDir)\external\nvngx_dlss_sdk;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)\external\vulkan\include;$(SolutionDir)\external\xess\inc\xess;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)\external\xess\lib;$(LibraryPath)</LibraryPath>
@@ -117,6 +149,10 @@
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(ProjectDir);$(ProjectDir)include\;$(SolutionDir)external\vulkan\include;$(SolutionDir)external\nvngx_dlss_sdk;$(SolutionDir)external\xess\inc\xess;$(SolutionDir)external\xess\inc\xell;$(SolutionDir)external\xess\inc\xess_fg;$(SolutionDir)external\FidelityFX-SDK\ffx-api\include\ffx_api;$(SolutionDir)external\simpleini;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)external\spdlog\include;$(SolutionDir)external\freetype;$(SolutionDir)external\streamline;$(SolutionDir)external\streamline1;$(SolutionDir)external\nvapi;$(SolutionDir)external\nlohmann;$(SolutionDir)external\fakenvapi;$(SolutionDir)external\magic_enum\include\magic_enum;$(IncludePath)</IncludePath>
+    <LibraryPath>$(ProjectDir)library\fsr2;$(ProjectDir)library\fsr2_212;$(ProjectDir)library\fsr31;$(ProjectDir)library\vulkan;$(ProjectDir)library\d3dx;$(ProjectDir)library\detours;$(SolutionDir)external\xess\lib;$(SolutionDir)external\freetype;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">
     <IncludePath>$(ProjectDir);$(ProjectDir)include\;$(SolutionDir)external\vulkan\include;$(SolutionDir)external\nvngx_dlss_sdk;$(SolutionDir)external\xess\inc\xess;$(SolutionDir)external\xess\inc\xell;$(SolutionDir)external\xess\inc\xess_fg;$(SolutionDir)external\FidelityFX-SDK\ffx-api\include\ffx_api;$(SolutionDir)external\simpleini;$(SolutionDir)external\unordered_dense\include;$(SolutionDir)external\spdlog\include;$(SolutionDir)external\freetype;$(SolutionDir)external\streamline;$(SolutionDir)external\streamline1;$(SolutionDir)external\nvapi;$(SolutionDir)external\nlohmann;$(SolutionDir)external\fakenvapi;$(SolutionDir)external\magic_enum\include\magic_enum;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)library\fsr2;$(ProjectDir)library\fsr2_212;$(ProjectDir)library\fsr31;$(ProjectDir)library\vulkan;$(ProjectDir)library\d3dx;$(ProjectDir)library\detours;$(SolutionDir)external\xess\lib;$(SolutionDir)external\freetype;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
@@ -152,6 +188,29 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>OPTISCALER_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ForcedIncludeFiles>misc/Optiscaler_Static.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -268,6 +327,58 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
       <Command>powershell -NoProfile -Command "Start-Sleep -Milliseconds 1500; $date = Get-Date -Format 'yyyyMMdd_HHmmss'; $commit = (git rev-parse --short HEAD 2&gt;$null); if (-not $commit) { $commit = 'unknown' }; Set-Content -Path '$(ProjectDir)resource_build_date.h' -Value ('#define VER_BUILD_DATE \"' + $date + '\"') -Force; Set-Content -Path '$(ProjectDir)resource_build_commit.h' -Value ('#define VER_BUILD_COMMIT \"' + $commit + '\"') -Force;"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>OPTISCALER_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalOptions>/w34996 %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ForcedIncludeFiles>misc/Optiscaler_Static.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>winhttp.lib;WindowsApp.lib;Dbghelp.lib;dxgi.lib;d3d11.lib;d3d12.lib;vulkan-1.lib;dxguid.lib;freetype.lib;ffx_fsr2_api_x64.lib;ffx_fsr2_api_dx11_x64.lib;ffx_fsr2_api_dx12_x64.lib;ffx_fsr2_api_vk_x64.lib;ffx_fsr2_212_api_dx12_x64.lib;ffx_fsr2_212_api_vk_x64.lib;ffx_fsr2_212_api_x64.lib;d3dcompiler.lib;ffx_backend_dx11_x64.lib;ffx_fsr3_x64.lib;ffx_frameinterpolation_x64.lib;ffx_fsr3upscaler_x64.lib;ffx_opticalflow_x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
+      <DelayLoadDLLs>vulkan-1.dll;dxgi.dll;d3d12.dll;D3DCOMPILER_47.dll</DelayLoadDLLs>
+      <AdditionalOptions>/ignore:4099</AdditionalOptions>
+    </Link>
+    <PostBuildEvent>
+      <Command>md $(SolutionDir)x64\Release\a\
+move $(SolutionDir)x64\Release\$(TargetFileName) $(SolutionDir)x64\Release\a\
+md $(SolutionDir)x64\Release\a\Licenses
+del /Q $(SolutionDir)x64\Release\a\Licenses\*.*
+copy $(SolutionDir)external\xess\LICENSE.txt $(SolutionDir)x64\Release\a\Licenses\XeSS_LICENSE.txt /Y
+copy $(SolutionDir)external\xess\bin\*.dll $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)external\FidelityFX-SDK\docs\license.md $(SolutionDir)x64\Release\a\Licenses\FidelityFX_v1_LICENSE.md /Y
+copy $(SolutionDir)external\FidelityFX-SDK\PrebuiltSignedDLL\amd_fidelityfx_vk.dll $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)external\FidelityFX-SDK-v2\Kits\FidelityFX\signedbin\amd_fidelityfx_loader_dx12.dll $(SolutionDir)x64\Release\a\amd_fidelityfx_dx12.dll /Y
+copy $(SolutionDir)external\FidelityFX-SDK-v2\Kits\FidelityFX\signedbin\amd_fidelityfx_upscaler_dx12.dll $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)external\FidelityFX-SDK-v2\Kits\FidelityFX\signedbin\amd_fidelityfx_framegeneration_dx12.dll $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)external\FidelityFX-SDK-v2\docs\license.md $(SolutionDir)x64\Release\a\Licenses\FidelityFX_v2_LICENSE.md /Y
+copy $(SolutionDir)OptiScaler.ini $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)setup_windows.bat $(SolutionDir)x64\Release\a\ /Y
+copy $(SolutionDir)setup_linux.sh $(SolutionDir)x64\Release\a\ /Y
+md $(SolutionDir)x64\Release\a\D3D12_Optiscaler\
+copy "$(SolutionDir)external\directx_agility_sdk\lib\*.dll" $(SolutionDir)x64\Release\a\D3D12_Optiscaler\ /Y
+copy "$(SolutionDir)external\directx_agility_sdk\LICENSE.txt" $(SolutionDir)x64\Release\a\Licenses\DirectX_LICENSE.txt /Y
+copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>powershell -NoProfile -Command "Start-Sleep -Milliseconds 1500; $date = Get-Date -Format 'yyyyMMdd_HHmmss'; $commit = (git rev-parse --short HEAD 2&gt;$null); if (-not $commit) { $commit = 'unknown' }; Set-Content -Path '$(ProjectDir)resource_build_date.h' -Value ('#define VER_BUILD_DATE \"' + $date + '\"') -Force; Set-Content -Path '$(ProjectDir)resource_build_commit.h' -Value ('#define VER_BUILD_COMMIT \"' + $commit + '\"') -Force;"</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -323,6 +434,9 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="hooks\Hook_Utils.h" />
     <ClInclude Include="hooks\LibraryLoad_Hooks.h" />
     <ClInclude Include="hooks\CommandBuffer_StateTracker.h" />
+    <ClCompile Include="misc\Optiscaler_Static_API.cpp" />
+    <ClInclude Include="misc\Optiscaler_Static_API.h" />
+    <ClInclude Include="misc\Optiscaler_Static.h" />
     <ClInclude Include="shaders\rcas\precompile\da_das_sharpen_Shader.h" />
     <ClInclude Include="shaders\rcas\precompile\da_das_sharpen_Shader_Dx11.h" />
     <ClInclude Include="shaders\rcas\precompile\da_das_sharpen_Shader_Vk.h" />
@@ -570,6 +684,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="shaders\depth_invert\DI_Dx12.cpp" />
     <ClCompile Include="shaders\hud_copy\HudCopy_Dx12.cpp" />
@@ -599,31 +714,37 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_impl_dx12.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_impl_uwp.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_impl_vulkan.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_impl_win32.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\sl.param\parameters.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="inputs\FfxApiExe_Dx12.cpp" />
     <ClCompile Include="inputs\FG\FfxApi_Dx12_FG.cpp" />
@@ -691,26 +812,31 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_draw.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_tables.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\imgui_widgets.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="include\imgui\misc\freetype\imgui_freetype.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseDebug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="inputs\NVNGX.cpp" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -797,6 +797,12 @@
     <ClInclude Include="shaders\rcas\shaders\DA_RCAS_Shader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="misc\Optiscaler_Static.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="misc\Optiscaler_Static_API.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Config.cpp">
@@ -1203,6 +1209,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="spoofing\User32_Spoofing.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="misc\Optiscaler_Static_API.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/OptiScaler/misc/Optiscaler_Static.h
+++ b/OptiScaler/misc/Optiscaler_Static.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifdef OPTISCALER_STATIC
+
+#define DllMain org_dllMain
+#define GetFileVersionInfoSizeW SafeGetFileVersionInfoSizeW
+#define GetFileVersionInfoW SafeGetFileVersionInfoW
+#define VerQueryValueW SafeVerQueryValueW
+#endif

--- a/OptiScaler/misc/Optiscaler_Static_API.cpp
+++ b/OptiScaler/misc/Optiscaler_Static_API.cpp
@@ -1,0 +1,140 @@
+#include "pch.h"
+#include "Optiscaler_Static_API.h"
+
+#ifdef OPTISCALER_STATIC
+#include "../State.h"
+
+extern BOOL APIENTRY org_dllMain(HINSTANCE hModule, DWORD reason, LPVOID reserved);
+
+bool OptiScaler_Init(HMODULE self, const OptiScalerConfig* cfg)
+{
+    dllModule = self;
+    Config::Instance()->StreamlineSpoofing.set_volatile_value(false);
+    org_dllMain(self, DLL_PROCESS_ATTACH, NULL);
+    return true;
+}
+
+void OptiScaler_Shutdown() { org_dllMain(dllModule, DLL_PROCESS_DETACH, NULL); }
+
+BOOL WINAPI SafeGetFileVersionInfoW(LPCWSTR lpszFileName, DWORD dwHandle, DWORD dwLen, LPVOID lpData)
+{
+    typedef DWORD(WINAPI * LPFN_GetFileVersionInfoSizeW)(LPCWSTR, LPDWORD);
+    typedef BOOL(WINAPI * LPFN_GetFileVersionInfoW)(LPCWSTR, DWORD, DWORD, LPVOID);
+    typedef BOOL(WINAPI * LPFN_VerQueryValueW)(LPCVOID, LPCWSTR, LPVOID*, PUINT);
+
+    // Construct the full path to version.dll in the system32 directory
+    wchar_t systemDirectory[MAX_PATH];
+    UINT size = GetSystemDirectory(systemDirectory, MAX_PATH);
+    return false;
+    std::wstring versionDllPath = std::wstring(systemDirectory) + L"\\version.dll";
+
+    // Load version.dll from the system32 directory
+    HMODULE hVersionDll = LoadLibraryW(versionDllPath.c_str());
+    if (hVersionDll == NULL)
+    {
+        return false;
+    }
+
+    // Get the addresses of the functions
+    LPFN_GetFileVersionInfoSizeW pGetFileVersionInfoSize =
+        (LPFN_GetFileVersionInfoSizeW)::GetProcAddress(hVersionDll, "GetFileVersionInfoSizeW");
+    LPFN_GetFileVersionInfoW pGetFileVersionInfo =
+        (LPFN_GetFileVersionInfoW)::GetProcAddress(hVersionDll, "GetFileVersionInfoW");
+    LPFN_VerQueryValueW pVerQueryValue = (LPFN_VerQueryValueW)::GetProcAddress(hVersionDll, "VerQueryValueW");
+
+    if (!pGetFileVersionInfoSize || !pGetFileVersionInfo || !pVerQueryValue)
+    {
+        FreeLibrary(hVersionDll);
+        return false;
+    }
+
+    //  Get the size of the version information
+    DWORD verHandle = 0;
+    DWORD result = pGetFileVersionInfo(lpszFileName, dwHandle, dwLen, lpData);
+    FreeLibrary(hVersionDll);
+
+    return result;
+}
+
+DWORD WINAPI SafeGetFileVersionInfoSizeW(LPCWSTR lpszFileName, LPDWORD lpdwHandle)
+{
+    typedef DWORD(WINAPI * LPFN_GetFileVersionInfoSizeW)(LPCWSTR, LPDWORD);
+    typedef BOOL(WINAPI * LPFN_GetFileVersionInfoW)(LPCWSTR, DWORD, DWORD, LPVOID);
+    typedef BOOL(WINAPI * LPFN_VerQueryValueW)(LPCVOID, LPCWSTR, LPVOID*, PUINT);
+
+    // Construct the full path to version.dll in the system32 directory
+    wchar_t systemDirectory[MAX_PATH];
+    UINT size = GetSystemDirectory(systemDirectory, MAX_PATH);
+
+    std::wstring versionDllPath = std::wstring(systemDirectory) + L"\\version.dll";
+
+    // Load version.dll from the system32 directory
+    HMODULE hVersionDll = LoadLibraryW(versionDllPath.c_str());
+    if (hVersionDll == NULL)
+    {
+        return false;
+    }
+
+    // Get the addresses of the functions
+    LPFN_GetFileVersionInfoSizeW pGetFileVersionInfoSize =
+        (LPFN_GetFileVersionInfoSizeW)::GetProcAddress(hVersionDll, "GetFileVersionInfoSizeW");
+    LPFN_GetFileVersionInfoW pGetFileVersionInfo =
+        (LPFN_GetFileVersionInfoW)::GetProcAddress(hVersionDll, "GetFileVersionInfoW");
+    LPFN_VerQueryValueW pVerQueryValue = (LPFN_VerQueryValueW)::GetProcAddress(hVersionDll, "VerQueryValueW");
+
+    if (!pGetFileVersionInfoSize || !pGetFileVersionInfo || !pVerQueryValue)
+    {
+        FreeLibrary(hVersionDll);
+        return false;
+    }
+
+    // Get the size of the version information
+    DWORD verHandle = 0;
+    DWORD verSize = pGetFileVersionInfoSize(lpszFileName, lpdwHandle);
+    FreeLibrary(hVersionDll);
+
+    return verSize;
+}
+
+BOOL WINAPI SafeVerQueryValueW(LPCVOID pBlock, LPCWSTR lpSubBlock, LPVOID* lplpBuffer, PUINT puLen)
+{
+
+    typedef DWORD(WINAPI * LPFN_GetFileVersionInfoSizeW)(LPCWSTR, LPDWORD);
+    typedef BOOL(WINAPI * LPFN_GetFileVersionInfoW)(LPCWSTR, DWORD, DWORD, LPVOID);
+    typedef BOOL(WINAPI * LPFN_VerQueryValueW)(LPCVOID, LPCWSTR, LPVOID*, PUINT);
+
+    // Construct the full path to version.dll in the system32 directory
+    wchar_t systemDirectory[MAX_PATH];
+    UINT size = GetSystemDirectory(systemDirectory, MAX_PATH);
+    return false;
+    std::wstring versionDllPath = std::wstring(systemDirectory) + L"\\version.dll";
+
+    // Load version.dll from the system32 directory
+    HMODULE hVersionDll = LoadLibraryW(versionDllPath.c_str());
+    if (hVersionDll == NULL)
+    {
+        return false;
+    }
+
+    // Get the addresses of the functions
+    LPFN_GetFileVersionInfoSizeW pGetFileVersionInfoSize =
+        (LPFN_GetFileVersionInfoSizeW)::GetProcAddress(hVersionDll, "GetFileVersionInfoSizeW");
+    LPFN_GetFileVersionInfoW pGetFileVersionInfo =
+        (LPFN_GetFileVersionInfoW)::GetProcAddress(hVersionDll, "GetFileVersionInfoW");
+    LPFN_VerQueryValueW pVerQueryValue = (LPFN_VerQueryValueW)::GetProcAddress(hVersionDll, "VerQueryValueW");
+
+    if (!pGetFileVersionInfoSize || !pGetFileVersionInfo || !pVerQueryValue)
+    {
+        FreeLibrary(hVersionDll);
+        return false;
+    }
+
+    //  Get the size of the version information
+    DWORD verHandle = 0;
+    DWORD verSize = pVerQueryValue(pBlock, lpSubBlock, lplpBuffer, puLen);
+    FreeLibrary(hVersionDll);
+
+    return verSize;
+}
+
+#endif

--- a/OptiScaler/misc/Optiscaler_Static_API.h
+++ b/OptiScaler/misc/Optiscaler_Static_API.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <windows.h>
+
+struct OptiScalerConfig
+{
+
+};
+
+bool OptiScaler_Init(HMODULE self, const OptiScalerConfig* cfg);
+void OptiScaler_Shutdown();

--- a/OptiScaler/proxies/NVNGX_Proxy.h
+++ b/OptiScaler/proxies/NVNGX_Proxy.h
@@ -443,7 +443,7 @@ class NVNGXProxy
             _module.dll = nvngxModule;
         }
 
-        std::vector<std::wstring> dllNames = { L"_nvngx.dll", L"nvngx.dll" };
+        std::vector<std::wstring> dllNames = { L"dlss-enabler-ngx.dll", L"_nvngx.dll", L"nvngx.dll" };
 
         auto optiPath = Config::Instance()->MainDllPath.value();
         auto overridePath = Config::Instance()->NvngxPath.value_or(L"");


### PR DESCRIPTION
## Summary

Adds the ability to build OptiScaler as a **static library** and embed it into a
host DLL (e.g. DLSS Enabler), alongside the existing standalone DLL build.
All new behavior is gated behind the `OPTISCALER_STATIC` macro and a dedicated
build configuration, so the default DLL build path is completely unaffected.

## Changes

- **New `ReleaseStatic` build configuration.** Builds OptiScaler as a static `.lib`
  with the static CRT (`/MT`) and defines `OPTISCALER_STATIC`. Because the CRT is
  linked statically, any static dependencies it pulls in (e.g. the FSR3 /
  FidelityFX SDK) must be compiled in the same `/MT` mode — mixing `/MT` and `/MD`
  within one module causes CRT symbol conflicts.
- **`DllMain` demotion (static build only).** Under `OPTISCALER_STATIC`, `DllMain`
  is renamed to `org_dllMain` via a forced-include macro. It stops being the module
  entry point and becomes a regular function the host can call. In standard DLL
  builds the macro is not defined, so `DllMain` remains the entry point as before.
- **Public embedding API.** `OptiScaler_Init(HMODULE self, const OptiScalerConfig* cfg)`
  and `OptiScaler_Shutdown()` forward to the original `DllMain` logic with
  `DLL_PROCESS_ATTACH` / `DLL_PROCESS_DETACH`, preserving the existing init and
  cleanup paths. The host passes its own module handle for module-relative lookups.
- **`OptiScalerConfig`** struct for future use.
- **Duplicate-symbol fixes** that surfaced when linking statically alongside the
  host's own version-check code.