### PR TITLE
Fix: Resolve memory access violation error occurring when the filename is 'version.dll'.

### DIFF
--- a/OptiScaler/Util.cpp
+++ b/OptiScaler/Util.cpp
@@ -1,4 +1,4 @@
-#include "pch.h"
+﻿#include "pch.h"
 
 #include "Util.h"
 #include "Config.h"
@@ -177,7 +177,8 @@ void Util::GetExeInfo()
     GetSystemDirectory(sysFolder, MAX_PATH);
     std::filesystem::path sysPath(sysFolder);
 
-    auto dll = LoadLibraryExW(L"version.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    // func CheckWorkingMode hasn't run.Don't load self.
+    auto dll = NtdllProxy::LoadLibraryExW_Ldr(L"version.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     if (dll == nullptr)
         return;

--- a/OptiScaler/hooks/Xell_Hooks.cpp
+++ b/OptiScaler/hooks/Xell_Hooks.cpp
@@ -80,14 +80,14 @@ bool XellHooks::update()
 
     gamesContextCanLimitFps = true;
 
-    static float lastFpslimit = 0.0f;
-    if (lastFpslimit == Config::Instance()->FramerateLimit.value_or_default())
+    static float lastFpsLimit = 0.0f;
+    if (lastFpsLimit == Config::Instance()->FramerateLimit.value_or_default())
         return false;
-    lastFpslimit = Config::Instance()->FramerateLimit.value_or_default();
-    if (lastFpslimit <= 0.0f)
+    lastFpsLimit = Config::Instance()->FramerateLimit.value_or_default();
+    if (lastFpsLimit <= 0.0f)
         currentParams.minimumIntervalUs = 0u;
     else
-        currentParams.minimumIntervalUs = static_cast<uint32_t>(std::round(1'000'000 / lastFpslimit));
+        currentParams.minimumIntervalUs = static_cast<uint32_t>(std::round(1'000'000 / lastFpsLimit));
 
     return o_xellSetSleepMode(gamesContext, &currentParams) == XELL_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Using 'version.dll' as a filename causes an error; this PR fixes it.