### PR TITLE
Fix upscaler-fed DLSSG resource-transition corruption

### DIFF
--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -297,6 +297,22 @@ ShowDebug = auto
 ; true or false - Default (auto) is false
 DisableHudless = auto
 
+; Controls bounded recovery when the upscaler-fed DLSSG path observes a frame-generation,
+; swapchain, input reset, or internal resource-tagging lifecycle boundary.
+; 0 = off | 1 = observe only | 2 = disable, drain, warm inputs, and re-enable DLSSG
+; integer 0-2 - Default (auto) is 0
+LifecycleMode = auto
+
+; Consecutive frames with valid depth and motion-vector inputs required before
+; lifecycle recovery can re-enable DLSSG.
+; integer 1-120 - Default (auto) is 10
+LifecycleWarmupFrames = auto
+
+; Maximum time spent waiting for already-submitted OptiScaler-owned work.
+; A timeout fails closed and does not re-enable DLSSG.
+; integer 100-10000 milliseconds - Default (auto) is 5000
+LifecycleDrainTimeoutMs = auto
+
 
 ; -------------------------------------------------------
 [OptiFG]

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -228,6 +228,21 @@ bool Config::Reload(std::filesystem::path iniPath)
             FGDLSSGDispatchFlags.set_from_config(readUInt("DLSSG", "DispatchFlags"));
             FGDLSSGShowDebug.set_from_config(readUInt("DLSSG", "ShowDebug"));
             FGDLSSGDisableHudless.set_from_config(readBool("DLSSG", "DisableHudless"));
+
+            FGDLSSGLifecycleMode.set_from_config(readInt("DLSSG", "LifecycleMode"));
+            if (FGDLSSGLifecycleMode.has_value() &&
+                (FGDLSSGLifecycleMode.value() < 0 || FGDLSSGLifecycleMode.value() > 2))
+                FGDLSSGLifecycleMode.reset();
+
+            FGDLSSGLifecycleWarmupFrames.set_from_config(readInt("DLSSG", "LifecycleWarmupFrames"));
+            if (FGDLSSGLifecycleWarmupFrames.has_value() &&
+                (FGDLSSGLifecycleWarmupFrames.value() < 1 || FGDLSSGLifecycleWarmupFrames.value() > 120))
+                FGDLSSGLifecycleWarmupFrames.reset();
+
+            FGDLSSGLifecycleDrainTimeoutMs.set_from_config(readInt("DLSSG", "LifecycleDrainTimeoutMs"));
+            if (FGDLSSGLifecycleDrainTimeoutMs.has_value() &&
+                (FGDLSSGLifecycleDrainTimeoutMs.value() < 100 || FGDLSSGLifecycleDrainTimeoutMs.value() > 10000))
+                FGDLSSGLifecycleDrainTimeoutMs.reset();
         }
 
         // FSR FG Inputs
@@ -981,6 +996,12 @@ bool Config::SaveIni()
         ini.SetValue("DLSSG", "ShowDebug", GetIntValue(Instance()->FGDLSSGShowDebug.value_for_config()).c_str());
         ini.SetValue("DLSSG", "DisableHudless",
                      GetBoolValue(Instance()->FGDLSSGDisableHudless.value_for_config()).c_str());
+        ini.SetValue("DLSSG", "LifecycleMode",
+                     GetIntValue(Instance()->FGDLSSGLifecycleMode.value_for_config()).c_str());
+        ini.SetValue("DLSSG", "LifecycleWarmupFrames",
+                     GetIntValue(Instance()->FGDLSSGLifecycleWarmupFrames.value_for_config()).c_str());
+        ini.SetValue("DLSSG", "LifecycleDrainTimeoutMs",
+                     GetIntValue(Instance()->FGDLSSGLifecycleDrainTimeoutMs.value_for_config()).c_str());
     }
 
     // OptiFG

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -603,6 +603,9 @@ class Config
     CustomOptional<uint32_t> FGDLSSGDispatchFlags { 0 };
     CustomOptional<uint32_t> FGDLSSGShowDebug { 0 };
     CustomOptional<bool> FGDLSSGDisableHudless { false };
+    CustomOptional<int> FGDLSSGLifecycleMode { 0 };
+    CustomOptional<int> FGDLSSGLifecycleWarmupFrames { 10 };
+    CustomOptional<int> FGDLSSGLifecycleDrainTimeoutMs { 5000 };
 
     // fakenvapi
     CustomOptional<bool> UseFakenvapi { true };

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -316,6 +316,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="exports\wininet.h" />
     <ClInclude Include="exports\winmm.h" />
     <ClInclude Include="framegen\dlssg\DLSSG_Dx12.h" />
+    <ClInclude Include="framegen\dlssg\DLSSG_Lifecycle.h" />
     <ClInclude Include="framegen\ffx\FSRFG_Dx12.h" />
     <ClInclude Include="framegen\IFGFeature.h" />
     <ClInclude Include="framegen\IFGFeature_Dx12.h" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -782,6 +782,9 @@
     <ClInclude Include="framegen\dlssg\DLSSG_Dx12.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="framegen\dlssg\DLSSG_Lifecycle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="shaders\hud_copy\precompile\HudCopy_Shader.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/OptiScaler/framegen/IFGFeature.h
+++ b/OptiScaler/framegen/IFGFeature.h
@@ -105,6 +105,7 @@ class IFGFeature
     virtual bool Shutdown() = 0;
     virtual bool HasResource(FG_ResourceType type, int index = -1) = 0;
     virtual bool SetInterpolatedFrameCount(UINT interpolatedFrameCount) = 0;
+    virtual void ProcessUpscalerLifecycle(bool, bool, bool, bool) {}
 
     int GetIndex();
     int GetIndexWillBeDispatched();

--- a/OptiScaler/framegen/IFGFeature_Dx12.cpp
+++ b/OptiScaler/framegen/IFGFeature_Dx12.cpp
@@ -78,6 +78,73 @@ bool IFGFeature_Dx12::WaitForUIAllocator(UINT index)
     return true;
 }
 
+bool IFGFeature_Dx12::DrainOwnedWork(DWORD timeoutMs)
+{
+    for (size_t index = 0; index < BUFFER_COUNT; index++)
+    {
+        if (_uiCommandListResetted[index] || _scCommandListResetted[index])
+        {
+            LOG_ERROR("Lifecycle drain found an unsubmitted OptiScaler command list in slot {}", index);
+            return false;
+        }
+    }
+
+    if (_gameCommandQueue == nullptr || _scFence == nullptr || _scFenceEvent == nullptr)
+    {
+        LOG_ERROR("Lifecycle drain requires a command queue, fence, and fence event");
+        return false;
+    }
+
+    const auto fenceValue = ++_lifecycleFenceValue;
+    const auto signalResult = _gameCommandQueue->Signal(_scFence, fenceValue);
+    if (FAILED(signalResult))
+    {
+        LOG_ERROR("Lifecycle queue fence signal failed. fence {}, result {:X}", fenceValue, (UINT) signalResult);
+        return false;
+    }
+
+    const auto eventResult = _scFence->SetEventOnCompletion(fenceValue, _scFenceEvent);
+    if (FAILED(eventResult))
+    {
+        LOG_ERROR("Lifecycle queue fence SetEventOnCompletion failed. fence {}, result {:X}", fenceValue,
+                  (UINT) eventResult);
+        return false;
+    }
+
+    const auto waitResult = WaitForSingleObject(_scFenceEvent, timeoutMs);
+    if (waitResult != WAIT_OBJECT_0)
+    {
+        LOG_ERROR("Lifecycle queue fence wait failed. fence {}, completed {}, waitResult {:X}", fenceValue,
+                  _scFence->GetCompletedValue(), waitResult);
+        return false;
+    }
+
+    return _scFence->GetCompletedValue() >= fenceValue;
+}
+
+void IFGFeature_Dx12::ResetLifecycleTracking()
+{
+    for (size_t index = 0; index < BUFFER_COUNT; index++)
+    {
+        std::unique_lock<std::shared_mutex> lock(_resourceMutex[index]);
+        _frameResources[index].clear();
+        _resourceReady[index].clear();
+        _waitingExecute[index] = false;
+        _noUi[index] = true;
+        _noDistortionField[index] = true;
+        _noHudless[index] = true;
+    }
+
+    // _resourceCopy contains OptiScaler-owned reusable allocations. Keep those
+    // alive; this stage invalidates tracking only and never releases game-owned
+    // resources.
+    _resourceFrame.clear();
+    _waitingNewFrameData = false;
+    _lastDispatchedFrame = _frameCount;
+    _lastFGFrame = _frameCount;
+    ResetCounters();
+}
+
 ID3D12GraphicsCommandList* IFGFeature_Dx12::GetUICommandList(int index)
 {
     if (index < 0 || index >= BUFFER_COUNT)

--- a/OptiScaler/framegen/IFGFeature_Dx12.h
+++ b/OptiScaler/framegen/IFGFeature_Dx12.h
@@ -68,6 +68,7 @@ class IFGFeature_Dx12 : public virtual IFGFeature
     UINT64 _scAllocatorFenceValues[BUFFER_COUNT] {};
     ID3D12Fence* _scFence = nullptr;
     HANDLE _scFenceEvent = nullptr;
+    UINT64 _lifecycleFenceValue = 0;
 
     ID3D12GraphicsCommandList* _uiCommandList[BUFFER_COUNT] {};
     ID3D12CommandAllocator* _uiCommandAllocator[BUFFER_COUNT] {};
@@ -96,6 +97,8 @@ class IFGFeature_Dx12 : public virtual IFGFeature
 
     void NewFrame() override final;
     void FlipResource(Dx12Resource* resource);
+    bool DrainOwnedWork(DWORD timeoutMs);
+    void ResetLifecycleTracking();
 
   protected:
     virtual void ReleaseObjects() = 0;

--- a/OptiScaler/framegen/dlssg/DLSSG_Dx12.cpp
+++ b/OptiScaler/framegen/dlssg/DLSSG_Dx12.cpp
@@ -256,9 +256,12 @@ void DLSSG_Dx12::CreateContext(ID3D12Device* device, FG_Constants& fgConstants)
     if (_isActive)
     {
         LOG_INFO("FG context recreated while active, pausing");
-        State::Instance().fgChanged = true;
-        UpdateTarget();
-        Deactivate();
+        if (!RequestLifecycleTransition("context-recreated"))
+        {
+            State::Instance().fgChanged = true;
+            UpdateTarget();
+            Deactivate();
+        }
     }
 }
 
@@ -272,6 +275,31 @@ void DLSSG_Dx12::Activate()
         UpdateTarget();
         _isActive = true;
     }
+}
+
+void DLSSG_Dx12::ActivateAfterLifecycleWarmup()
+{
+    if (_isActive)
+        return;
+
+    // The lifecycle controller already observed the configured warm-up. Set
+    // the target to the current frame so StartNewFrame unpauses this frame
+    // without Activate() adding the legacy second ten-frame delay.
+    ResetCounters();
+    _isActive = true;
+}
+
+bool DLSSG_Dx12::RequestLifecycleTransition(const char* reason)
+{
+    if (Config::Instance()->FGDLSSGLifecycleMode.value_or_default() !=
+        static_cast<int>(optiscaler::dlssg::LifecycleMode::Cycle))
+    {
+        return false;
+    }
+
+    _lifecycleRequestPending.store(true, std::memory_order_release);
+    LOG_WARN("DLSSG lifecycle transition requested: {}", reason == nullptr ? "unspecified" : reason);
+    return true;
 }
 
 void DLSSG_Dx12::Deactivate()
@@ -534,9 +562,12 @@ bool DLSSG_Dx12::Dispatch()
     {
         LOG_ERROR("GetNewFrameToken error: {} ({})", magic_enum::enum_name(tokenResult), (UINT) tokenResult);
 
-        state.fgChanged = true;
-        UpdateTarget();
-        Deactivate();
+        if (!RequestLifecycleTransition("get-frame-token-failed"))
+        {
+            state.fgChanged = true;
+            UpdateTarget();
+            Deactivate();
+        }
 
         return false;
     }
@@ -546,9 +577,12 @@ bool DLSSG_Dx12::Dispatch()
     {
         LOG_ERROR("SetConstants error: {} ({})", magic_enum::enum_name(result), (UINT) result);
 
-        state.fgChanged = true;
-        UpdateTarget();
-        Deactivate();
+        if (!RequestLifecycleTransition("set-constants-failed"))
+        {
+            state.fgChanged = true;
+            UpdateTarget();
+            Deactivate();
+        }
 
         return false;
     }
@@ -566,6 +600,101 @@ DLSSG_Dx12::~DLSSG_Dx12() { Shutdown(); }
 
 bool DLSSG_Dx12::SetInterpolatedFrameCount(UINT interpolatedFrameCount) { return true; }
 
+void DLSSG_Dx12::ProcessUpscalerLifecycle(bool fgChanged, bool swapchainChanged, bool reset, bool validInputs)
+{
+    using optiscaler::dlssg::LifecycleMode;
+    using optiscaler::dlssg::LifecycleModeName;
+    using optiscaler::dlssg::LifecyclePhaseName;
+
+    auto& cfg = *Config::Instance();
+    auto& state = State::Instance();
+
+    const auto mode = static_cast<LifecycleMode>(cfg.FGDLSSGLifecycleMode.value_or_default());
+    _lifecycleController.Configure(mode, static_cast<uint32_t>(cfg.FGDLSSGLifecycleWarmupFrames.value_or_default()));
+
+    const auto internalRequest = _lifecycleRequestPending.exchange(false, std::memory_order_acq_rel);
+    if (internalRequest)
+        _lifecycleController.RequestCycle();
+
+    const auto lifecycleOwnsActivation = _lifecycleController.OwnsActivation();
+    const auto decision = _lifecycleController.Step({
+        .fgChanged = fgChanged,
+        .swapchainChanged = swapchainChanged,
+        .reset = reset,
+        .validInputs = validInputs,
+        .runtimeReady = cfg.FGEnabled.value_or_default() && _device != nullptr &&
+                        state.currentFGSwapchain != nullptr && _gameCommandQueue != nullptr &&
+                        (_isActive || lifecycleOwnsActivation),
+    });
+
+    if (mode != LifecycleMode::Off && decision.logSignalChange)
+    {
+        LOG_INFO("DLSSG lifecycle signals changed: mode={}, mask=0x{:X}, phase={}, validInputs={}",
+                 LifecycleModeName(mode), decision.triggerMask, LifecyclePhaseName(decision.phase), validInputs);
+    }
+
+    if (decision.logHeartbeat)
+    {
+        LOG_INFO("DLSSG lifecycle heartbeat: mode={}, phase={}, warmup={}/{}, frame={}", LifecycleModeName(mode),
+                 LifecyclePhaseName(decision.phase), decision.validWarmupFrames, _lifecycleController.WarmupFrames(),
+                 _frameCount);
+    }
+
+    if (mode != LifecycleMode::Cycle)
+        return;
+
+    if (decision.beginCycle)
+    {
+        OwnedLockGuard lock(Mutex, 556);
+
+        // Latch and consume the state flags before EvaluateState can clear them
+        // or run its legacy UpdateTarget path.
+        state.fgChanged = false;
+        state.scChanged = false;
+
+        LOG_WARN("DLSSG lifecycle cycle begin: mask=0x{:X}, reason={}, frame={}", decision.triggerMask,
+                 internalRequest ? "internal-request" : "state-signal", _frameCount);
+
+        // DLSSGSetOptions(eOff) is issued before any tracking reset. No
+        // Streamline shutdown or game-owned resource release occurs here.
+        Deactivate();
+
+        const auto drainTimeout = static_cast<DWORD>(cfg.FGDLSSGLifecycleDrainTimeoutMs.value_or_default());
+        if (!DrainOwnedWork(drainTimeout))
+        {
+            _lifecycleController.FailClosed();
+            LOG_ERROR("DLSSG lifecycle drain failed; frame generation remains disabled (timeout={} ms)", drainTimeout);
+            return;
+        }
+
+        ResetLifecycleTracking();
+        state.clearCapturedHudlesses = true;
+        Hudfix_Dx12::ResetCounters();
+        LOG_INFO("DLSSG lifecycle drain complete; observing {} consecutive valid input frames",
+                 _lifecycleController.WarmupFrames());
+        return;
+    }
+
+    if (_lifecycleController.OwnsActivation() || decision.reenable)
+    {
+        state.fgChanged = false;
+        state.scChanged = false;
+    }
+
+    if (decision.warmupCompleted)
+    {
+        LOG_INFO("DLSSG lifecycle input warm-up complete at frame {}; re-enable deferred to next valid frame",
+                 _frameCount);
+    }
+
+    if (decision.reenable)
+    {
+        OwnedLockGuard lock(Mutex, 557);
+        ActivateAfterLifecycleWarmup();
+        LOG_WARN("DLSSG lifecycle cycle complete; frame generation re-enabled at frame {}", _frameCount);
+    }
+}
+
 void DLSSG_Dx12::EvaluateState(ID3D12Device* device, FG_Constants& fgConstants)
 {
     LOG_FUNC();
@@ -573,6 +702,7 @@ void DLSSG_Dx12::EvaluateState(ID3D12Device* device, FG_Constants& fgConstants)
     OwnedLockGuard lock(Mutex, 555);
 
     auto& state = State::Instance();
+    const auto lifecycleOwnsActivation = _lifecycleController.OwnsActivation();
 
     // If needed hooks are missing or XeFG proxy is not inited or FG swapchain is not created
     if (!StreamlineProxy::LoadStreamline() || state.currentFGSwapchain == nullptr)
@@ -593,7 +723,7 @@ void DLSSG_Dx12::EvaluateState(ID3D12Device* device, FG_Constants& fgConstants)
             // Create it again
             CreateContext(device, fgConstants);
         }
-        else if (state.fgChanged)
+        else if (state.fgChanged && !lifecycleOwnsActivation)
         {
             LOG_DEBUG("FGChanged");
             Deactivate();
@@ -602,7 +732,8 @@ void DLSSG_Dx12::EvaluateState(ID3D12Device* device, FG_Constants& fgConstants)
             UpdateTarget();
         }
 
-        if (State::Instance().activeFgInput == FGInput::Upscaler && !IsPaused() && !IsActive())
+        if (State::Instance().activeFgInput == FGInput::Upscaler && !lifecycleOwnsActivation && !IsPaused() &&
+            !IsActive())
             Activate();
     }
     else
@@ -614,7 +745,7 @@ void DLSSG_Dx12::EvaluateState(ID3D12Device* device, FG_Constants& fgConstants)
         Hudfix_Dx12::ResetCounters();
     }
 
-    if (state.fgChanged)
+    if (state.fgChanged && !lifecycleOwnsActivation)
     {
         LOG_DEBUG("FGchanged");
 
@@ -1106,9 +1237,12 @@ bool DLSSG_Dx12::SetResource(Dx12Resource* inputResource)
 
             if (result != sl::Result::eOk)
             {
-                State::Instance().fgChanged = true;
-                UpdateTarget();
-                Deactivate();
+                if (!RequestLifecycleTransition("set-tag-for-frame-failed"))
+                {
+                    State::Instance().fgChanged = true;
+                    UpdateTarget();
+                    Deactivate();
+                }
 
                 return false;
             }

--- a/OptiScaler/framegen/dlssg/DLSSG_Dx12.h
+++ b/OptiScaler/framegen/dlssg/DLSSG_Dx12.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <framegen/IFGFeature_Dx12.h>
+#include "DLSSG_Lifecycle.h"
 
 #include <proxies/Streamline_Proxy.h>
+
+#include <atomic>
 
 class DLSSG_Dx12 : public virtual IFGFeature_Dx12
 {
@@ -16,8 +19,12 @@ class DLSSG_Dx12 : public virtual IFGFeature_Dx12
 
     ID3D12Fence* dlssgFence[BUFFER_COUNT] = {};
     UINT64 lastOptionFrame = 0;
+    optiscaler::dlssg::LifecycleController _lifecycleController;
+    std::atomic<bool> _lifecycleRequestPending { false };
 
     bool Dispatch();
+    bool RequestLifecycleTransition(const char* reason);
+    void ActivateAfterLifecycleWarmup();
 
   protected:
     void ReleaseObjects() override final;
@@ -45,6 +52,8 @@ class DLSSG_Dx12 : public virtual IFGFeature_Dx12
     bool Shutdown() override final;
 
     void EvaluateState(ID3D12Device* device, FG_Constants& fgConstants) override final;
+    void ProcessUpscalerLifecycle(bool fgChanged, bool swapchainChanged, bool reset,
+                                  bool validInputs) override final;
 
     bool Present() override final;
 

--- a/OptiScaler/framegen/dlssg/DLSSG_Lifecycle.h
+++ b/OptiScaler/framegen/dlssg/DLSSG_Lifecycle.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace optiscaler::dlssg
+{
+enum class LifecycleMode : uint8_t
+{
+    Off = 0,
+    Observe = 1,
+    Cycle = 2,
+};
+
+enum class LifecyclePhase : uint8_t
+{
+    Idle = 0,
+    WarmingInputs,
+    ReenablePending,
+    FailedClosed,
+};
+
+enum LifecycleTrigger : uint32_t
+{
+    TriggerNone = 0,
+    TriggerFgChanged = 1U << 0,
+    TriggerSwapchainChanged = 1U << 1,
+    TriggerReset = 1U << 2,
+    TriggerRequested = 1U << 3,
+};
+
+struct LifecycleObservation
+{
+    bool fgChanged = false;
+    bool swapchainChanged = false;
+    bool reset = false;
+    bool validInputs = false;
+    bool runtimeReady = true;
+};
+
+struct LifecycleDecision
+{
+    LifecyclePhase phase = LifecyclePhase::Idle;
+    uint32_t triggerMask = TriggerNone;
+    uint32_t validWarmupFrames = 0;
+    bool logSignalChange = false;
+    bool logHeartbeat = false;
+    bool beginCycle = false;
+    bool warmupCompleted = false;
+    bool reenable = false;
+};
+
+class LifecycleController
+{
+  private:
+    LifecycleMode _mode = LifecycleMode::Off;
+    LifecyclePhase _phase = LifecyclePhase::Idle;
+    uint32_t _warmupFrames = 10;
+    uint32_t _validWarmupFrames = 0;
+    uint32_t _lastTriggerMask = TriggerNone;
+    uint64_t _observationCount = 0;
+    uint64_t _heartbeatInterval = 600;
+    bool _cycleRequested = false;
+
+  public:
+    void Configure(LifecycleMode mode, uint32_t warmupFrames, uint64_t heartbeatInterval = 600);
+    void RequestCycle();
+    LifecycleDecision Step(const LifecycleObservation& observation);
+    void FailClosed();
+
+    LifecycleMode Mode() const { return _mode; }
+    LifecyclePhase Phase() const { return _phase; }
+    uint32_t ValidWarmupFrames() const { return _validWarmupFrames; }
+    uint32_t WarmupFrames() const { return _warmupFrames; }
+    bool OwnsActivation() const { return _mode == LifecycleMode::Cycle && _phase != LifecyclePhase::Idle; }
+};
+
+inline void LifecycleController::Configure(LifecycleMode mode, uint32_t warmupFrames, uint64_t heartbeatInterval)
+{
+    _warmupFrames = std::clamp(warmupFrames, 1U, 120U);
+    _heartbeatInterval = heartbeatInterval;
+
+    if (_mode == mode)
+        return;
+
+    _mode = mode;
+    _phase = LifecyclePhase::Idle;
+    _validWarmupFrames = 0;
+    _cycleRequested = false;
+}
+
+inline void LifecycleController::RequestCycle() { _cycleRequested = true; }
+
+inline LifecycleDecision LifecycleController::Step(const LifecycleObservation& observation)
+{
+    LifecycleDecision decision {};
+    _observationCount++;
+
+    if (observation.fgChanged)
+        decision.triggerMask |= TriggerFgChanged;
+    if (observation.swapchainChanged)
+        decision.triggerMask |= TriggerSwapchainChanged;
+    if (observation.reset)
+        decision.triggerMask |= TriggerReset;
+    if (_cycleRequested)
+        decision.triggerMask |= TriggerRequested;
+
+    decision.logSignalChange = decision.triggerMask != _lastTriggerMask;
+    decision.logHeartbeat = _mode != LifecycleMode::Off && _heartbeatInterval > 0 &&
+                            (_observationCount % _heartbeatInterval) == 0;
+    _lastTriggerMask = decision.triggerMask;
+
+    if (_mode != LifecycleMode::Cycle || _phase == LifecyclePhase::FailedClosed)
+    {
+        decision.phase = _phase;
+        decision.validWarmupFrames = _validWarmupFrames;
+        return decision;
+    }
+
+    if (_phase == LifecyclePhase::Idle && decision.triggerMask != TriggerNone && observation.runtimeReady)
+    {
+        _phase = LifecyclePhase::WarmingInputs;
+        _validWarmupFrames = 0;
+        _cycleRequested = false;
+        decision.beginCycle = true;
+        decision.phase = _phase;
+        return decision;
+    }
+
+    if (_phase != LifecyclePhase::Idle)
+        _cycleRequested = false;
+
+    if (_phase == LifecyclePhase::WarmingInputs)
+    {
+        if (observation.validInputs && observation.runtimeReady)
+            _validWarmupFrames++;
+        else
+            _validWarmupFrames = 0;
+
+        if (_validWarmupFrames >= _warmupFrames)
+        {
+            _phase = LifecyclePhase::ReenablePending;
+            decision.warmupCompleted = true;
+        }
+    }
+    else if (_phase == LifecyclePhase::ReenablePending && observation.validInputs && observation.runtimeReady)
+    {
+        _phase = LifecyclePhase::Idle;
+        decision.reenable = true;
+    }
+
+    decision.phase = _phase;
+    decision.validWarmupFrames = _validWarmupFrames;
+    return decision;
+}
+
+inline void LifecycleController::FailClosed()
+{
+    _phase = LifecyclePhase::FailedClosed;
+    _cycleRequested = false;
+}
+
+inline const char* LifecycleModeName(LifecycleMode mode)
+{
+    switch (mode)
+    {
+    case LifecycleMode::Off:
+        return "off";
+    case LifecycleMode::Observe:
+        return "observe";
+    case LifecycleMode::Cycle:
+        return "cycle";
+    }
+
+    return "unknown";
+}
+
+inline const char* LifecyclePhaseName(LifecyclePhase phase)
+{
+    switch (phase)
+    {
+    case LifecyclePhase::Idle:
+        return "idle";
+    case LifecyclePhase::WarmingInputs:
+        return "warming-inputs";
+    case LifecyclePhase::ReenablePending:
+        return "reenable-pending";
+    case LifecyclePhase::FailedClosed:
+        return "failed-closed";
+    }
+
+    return "unknown";
+}
+} // namespace optiscaler::dlssg

--- a/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
+++ b/OptiScaler/inputs/FG/Upscaler_Inputs_Dx12.cpp
@@ -115,10 +115,25 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
     if (Config::Instance()->FGAsync.value_or_default())
         fgConstants.flags |= FG_Flags::Async;
 
-    fg->EvaluateState(_device, fgConstants);
-
     int reset = 0;
     InParameters->Get(NVSDK_NGX_Parameter_Reset, &reset);
+
+    ID3D12Resource* paramVelocity = nullptr;
+    if (InParameters->Get(NVSDK_NGX_Parameter_MotionVectors, &paramVelocity) != NVSDK_NGX_Result_Success)
+        InParameters->Get(NVSDK_NGX_Parameter_MotionVectors, (void**) &paramVelocity);
+
+    ID3D12Resource* paramDepth = nullptr;
+    if (InParameters->Get(NVSDK_NGX_Parameter_Depth, &paramDepth) != NVSDK_NGX_Result_Success)
+        InParameters->Get(NVSDK_NGX_Parameter_Depth, (void**) &paramDepth);
+
+    const auto validLifecycleInputs = paramVelocity != nullptr && paramDepth != nullptr && feature->RenderWidth() > 0 &&
+                                      feature->RenderHeight() > 0 && feature->DisplayWidth() > 0 &&
+                                      feature->DisplayHeight() > 0;
+
+    // Latch lifecycle signals before EvaluateState consumes fgChanged. Recovery
+    // mode may own a serialized disable, drain, warm-up, and re-enable transition.
+    fg->ProcessUpscalerLifecycle(state.fgChanged, state.scChanged, reset != 0, validLifecycleInputs);
+    fg->EvaluateState(_device, fgConstants);
 
     InParameters->Get(NVSDK_NGX_Parameter_MV_Scale_X, &mvScaleX);
     InParameters->Get(NVSDK_NGX_Parameter_MV_Scale_Y, &mvScaleY);
@@ -158,10 +173,6 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
 
         LOG_DEBUG("(FG) copy buffers for fgUpscaledImage[{}], frame: {}", frameIndex, fg->FrameCount());
 
-        ID3D12Resource* paramVelocity = nullptr;
-        if (InParameters->Get(NVSDK_NGX_Parameter_MotionVectors, &paramVelocity) != NVSDK_NGX_Result_Success)
-            InParameters->Get(NVSDK_NGX_Parameter_MotionVectors, (void**) &paramVelocity);
-
         if (paramVelocity != nullptr)
         {
             Dx12Resource setResource {};
@@ -185,10 +196,6 @@ void UpscalerInputsDx12::UpscaleStart(ID3D12GraphicsCommandList* InCmdList, NVSD
 
             fg->SetResource(&setResource);
         }
-
-        ID3D12Resource* paramDepth = nullptr;
-        if (InParameters->Get(NVSDK_NGX_Parameter_Depth, &paramDepth) != NVSDK_NGX_Result_Success)
-            InParameters->Get(NVSDK_NGX_Parameter_Depth, (void**) &paramDepth);
 
         if (paramDepth != nullptr)
         {

--- a/tests/DLSSG_Lifecycle_Tests.vcxproj
+++ b/tests/DLSSG_Lifecycle_Tests.vcxproj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{F963543B-CA1C-45A2-A3D6-A05471D8098D}</ProjectGuid>
+    <RootNamespace>DLSSGLifecycleTests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dlssg_lifecycle_test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\OptiScaler\framegen\dlssg\DLSSG_Lifecycle.h" />
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/tests/dlssg_lifecycle_test.cpp
+++ b/tests/dlssg_lifecycle_test.cpp
@@ -1,0 +1,152 @@
+#include "pch.h"
+
+using namespace optiscaler::dlssg;
+
+static void off_mode_is_inert()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Off, 10);
+
+    const auto decision = controller.Step({ .fgChanged = true, .validInputs = true });
+    assert(!decision.beginCycle);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+}
+
+static void observe_mode_never_cycles()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Observe, 10);
+
+    auto decision = controller.Step({ .swapchainChanged = true, .validInputs = true });
+    assert(decision.logSignalChange);
+    assert(!decision.beginCycle);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(decision.logSignalChange);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+}
+
+static void trigger_frame_is_not_a_warmup_frame()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 2);
+
+    auto decision = controller.Step({ .reset = true, .validInputs = true });
+    assert(decision.beginCycle);
+    assert(decision.validWarmupFrames == 0);
+    assert(controller.Phase() == LifecyclePhase::WarmingInputs);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(!decision.reenable);
+    assert(decision.validWarmupFrames == 1);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(decision.warmupCompleted);
+    assert(controller.Phase() == LifecyclePhase::ReenablePending);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(decision.reenable);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+}
+
+static void invalid_input_restarts_the_warmup_count()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 2);
+
+    assert(controller.Step({ .fgChanged = true }).beginCycle);
+    assert(controller.Step({ .validInputs = true }).validWarmupFrames == 1);
+    assert(controller.Step({ .validInputs = false }).validWarmupFrames == 0);
+    assert(controller.Step({ .validInputs = true }).validWarmupFrames == 1);
+    assert(controller.Step({ .validInputs = true }).warmupCompleted);
+}
+
+static void repeated_triggers_do_not_restart_an_active_cycle()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 2);
+
+    assert(controller.Step({ .fgChanged = true }).beginCycle);
+    auto decision = controller.Step({ .fgChanged = true, .reset = true, .validInputs = true });
+    assert(!decision.beginCycle);
+    assert(decision.validWarmupFrames == 1);
+}
+
+static void explicit_requests_and_fail_closed_are_bounded()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 1);
+    controller.RequestCycle();
+
+    assert(controller.Step({}).beginCycle);
+    controller.FailClosed();
+    auto decision = controller.Step({ .validInputs = true });
+    assert(!decision.reenable);
+    assert(controller.Phase() == LifecyclePhase::FailedClosed);
+
+    controller.Configure(LifecycleMode::Observe, 1);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+}
+
+static void requested_cycle_waits_for_runtime_readiness()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 1);
+    controller.RequestCycle();
+
+    auto decision = controller.Step({ .runtimeReady = false });
+    assert(!decision.beginCycle);
+    assert(controller.Phase() == LifecyclePhase::Idle);
+
+    decision = controller.Step({ .runtimeReady = true });
+    assert(decision.beginCycle);
+}
+
+static void runtime_loss_blocks_warmup_and_reenable()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Cycle, 1);
+
+    assert(controller.Step({ .fgChanged = true }).beginCycle);
+
+    auto decision = controller.Step({ .validInputs = true, .runtimeReady = false });
+    assert(decision.validWarmupFrames == 0);
+    assert(controller.Phase() == LifecyclePhase::WarmingInputs);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(decision.warmupCompleted);
+
+    decision = controller.Step({ .validInputs = true, .runtimeReady = false });
+    assert(!decision.reenable);
+    assert(controller.Phase() == LifecyclePhase::ReenablePending);
+
+    decision = controller.Step({ .validInputs = true });
+    assert(decision.reenable);
+}
+
+static void heartbeat_is_sparse()
+{
+    LifecycleController controller;
+    controller.Configure(LifecycleMode::Observe, 10, 3);
+
+    assert(!controller.Step({}).logHeartbeat);
+    assert(!controller.Step({}).logHeartbeat);
+    assert(controller.Step({}).logHeartbeat);
+}
+
+int main()
+{
+    off_mode_is_inert();
+    observe_mode_never_cycles();
+    trigger_frame_is_not_a_warmup_frame();
+    invalid_input_restarts_the_warmup_count();
+    repeated_triggers_do_not_restart_an_active_cycle();
+    explicit_requests_and_fail_closed_are_bounded();
+    requested_cycle_waits_for_runtime_readiness();
+    runtime_loss_blocks_warmup_and_reenable();
+    heartbeat_is_sparse();
+
+    std::cout << "DLSSG lifecycle tests passed\n";
+    return 0;
+}

--- a/tests/pch.cpp
+++ b/tests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/tests/pch.h
+++ b/tests/pch.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "../OptiScaler/framegen/dlssg/DLSSG_Lifecycle.h"
+
+#include <cassert>
+#include <iostream>


### PR DESCRIPTION
## What this fixes

This patch fixes a resource-transition failure in OptiScaler's upscaler-fed DLSSG path.

In Jump Space running native D3D12 under Proton, 3x DLSSG initially produced repeatable 3-5 second freezes when targeting HUD information panels. Continued play accumulated visible ghosting, and a later scene/resource transition produced major full-frame artifacts. Disabling frame generation removed the artifacts immediately while the FSR 4.1.1 render remained clean.

With this patch, the same 3x workload completed an 84-minute test without a freeze, ghost trail, artifact, crash, or GPU reset. Coverage included the original HUD trigger, sustained motion, ship combat, two observed NGX reset transitions, post-transition play, return to the main menu, and normal exit.

## Reproducer

- Native D3D12 (`-force-d3d12`), not the D3D11-to-D3D12 bridge
- Radeon RX 9070 XT on Fedora/Proton
- FSR 4.1.1 through OptiScaler's upscaler input
- DLSS Enabler/Streamline providing the DLSSG backend
- Two interpolated frames (3x output)

```ini
FGEnabled = true
FGInput = upscaler
FGOutput = DLSSGWithNvngx

[DLSSG]
InterpolationCount = 2

[OptiFG]
HUDFix = true
DisableHUDFix = false
```

To reproduce the original failure, load a real mission and repeatedly move the targeting reticle onto an object that opens a HUD information panel. Continue normal movement and combat through a mission or scene transition.

## Before and after

| Test | Result |
| --- | --- |
| Original upscaler-fed DLSSG build at 3x | Repeatable 3-5 second HUD-triggered freezes, accumulating ghosting, then full-frame artifacts after a transition |
| Same scene with frame generation disabled | Artifacts stop immediately; FSR 4.1.1 remains clean |
| Patched build at 3x, `LifecycleMode=1` | 84 minutes clean across the original HUD trigger, combat, two reset transitions, post-transition play, menu return, and normal exit |

## Bug and fix

The upscaler-fed path previously called `EvaluateState()` before capturing the current NGX reset flag and depth/motion-vector inputs. That allowed DLSSG activation and OptiScaler's per-frame resource tracking to cross a resource transition without first observing the new input boundary.

This patch moves reset and input capture before `EvaluateState()` and latches the lifecycle signals before the existing state handling can consume them. The tested build observed two real reset transitions cleanly:

```text
DLSSG lifecycle signals changed: mode=observe, mask=0x4, phase=idle, validInputs=true
DLSSG lifecycle signals changed: mode=observe, mask=0x0, phase=idle, validInputs=true
```

That corrected path was sufficient to eliminate the original failure in testing.

The patch also includes an optional bounded recovery mode for workloads where capture and observation alone are not sufficient. It can disable DLSSG, drain submitted OptiScaler work, clear per-frame tracking, wait for consecutive valid inputs, and re-enable. A drain failure leaves frame generation disabled.

The optional active recovery mode was not needed for the verified Jump Space result. It was developed as the next bounded step during diagnosis, but the issue was already resolved with the tested observation path.

## Configuration

```ini
[DLSSG]
; 0 = off, 1 = observe only, 2 = bounded recovery
LifecycleMode = auto
LifecycleWarmupFrames = auto
LifecycleDrainTimeoutMs = auto
```

- `LifecycleMode=0`: current behavior without lifecycle logging or active recovery.
- `LifecycleMode=1`: the tested path; capture lifecycle signals and log transitions without running the recovery cycle.
- `LifecycleMode=2`: optional disable/drain/reset/warm/re-enable recovery.
- Warm-up defaults to 10 valid frames and is bounded to 1-120.
- Drain timeout defaults to 5000 ms and is bounded to 100-10000 ms.

## Validation

- The original failure was repeatable before the patch.
- Disabling frame generation immediately cleared the corruption, isolating it from the FSR 4.1.1 upscaler and base renderer.
- The patched `LifecycleMode=1` build passed the complete 84-minute 3x regression run described above.
- Lifecycle-controller tests cover disabled/observe behavior, warm-up counting, invalid-input reset, repeated triggers, explicit requests, fail-closed behavior, runtime-readiness loss, and sparse heartbeat logging.
- `git diff --check` and project XML parsing pass.
- The Windows [Build (No Signing)](https://github.com/gprocunier/OptiScaler/actions/runs/30835592918) passes.

## Review requested

- Is the pre-`EvaluateState()` upscaler-input boundary the right permanent location for reset/input capture?
- Should the optional active recovery remain in this change, or be split into later hardening now that the tested capture path resolves the reproducer?
- If retained, should active recovery drain the game queue as implemented or use a dedicated feature-submission fence?
