### PR TITLE
Fix dxvk-nvapi recursion in IdentifyGpu::queryNvapi (fixes #1101)

### DIFF
--- a/OptiScaler/misc/IdentifyGpu.cpp
+++ b/OptiScaler/misc/IdentifyGpu.cpp
@@ -194,6 +194,12 @@ std::vector<GpuInformation> IdentifyGpu::checkGpuInfo()
 
 void IdentifyGpu::queryNvapi(GpuInformation& gpuInfo)
 {
+    // Prevent recursion: NvAPI_Initialize (dxvk-nvapi) internally creates a DXGI factory
+    // and enumerates adapters, which re-enters our hooked EnumAdapters/EnumAdapters1 and
+    // calls getAllGpus() again while is_fetching is already set (returns empty list).
+    // Skip the DXGI load checks so nvapi sees the real adapters, allowing init to succeed.
+    ScopedSkipDxgiLoadChecks skipDxgiLoadChecks {};
+
     auto nvapiModule = NtdllProxy::LoadLibraryExW_Ldr(L"nvapi64.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     // No nvapi, should not be nvidia, possibly external spoofing


### PR DESCRIPTION
Fixes #1101

## Problem

On Linux/Proton, `IdentifyGpu::getAllGpus()` calls `queryNvapi()`, which calls
`NvAPI_Initialize`. Under dxvk-nvapi that internally creates a DXGI factory and
enumerates adapters -- which lands on OptiScaler's own hooked
`EnumAdapters`/`EnumAdapters1`. Those call `getAllGpus()` again, hit the
`is_fetching` guard, and return an empty list.

dxvk-nvapi therefore sees zero adapters, `NvAPI_Initialize` fails,
`dlssCapable` is never set, and DLSS is missing from the upscaler list (the game
silently falls back to FSR2).

## Fix

`ScopedSkipDxgiLoadChecks` already exists for exactly this situation, and both
`EnumAdapters` hooks honour it by passing straight through to
`o_EnumAdapters`/`o_EnumAdapters1`. Setting it for the duration of
`queryNvapi()` lets nvapi's internal enumeration see the real adapters.

## Verification

Death Stranding 2 on CachyOS Linux, Proton + DXVK/dxvk-nvapi, RTX 4070 SUPER.
From `OptiScaler.log`, before -> after:

| | before | after |
|---|---|---|
| nvapi init | `[E] IdentifyGpu::queryNvapi Failed to init NvApi` | gone |
| capabilities | `Upscaler support - fsr4: false, dlss: false` | `dlss: true` |
| driver seen by Streamline | `detected 0.0.0` | `getSystemCaps NVIDIA driver 610.57` |

DLSS then appears in the in-game upscaler menu and works.

Note on the base branch: this was verified on a `dlss-neural-rendering` fork
build (v10.0.0-dev). The changed function is byte-identical on `master`, and
`ScopedSkipDxgiLoadChecks` is unchanged there, so it rebased cleanly with no
conflict.

## Scope

6 lines in one file. No config, no public API changes.

---
*Investigation was AI-assisted; testing and verification were done on real
hardware, and the logs quoted above are from an actual game session.*
