### PR TITLE
Add an opt-out for Vulkan_wDx12 hooks on translated D3D workloads

### DIFF
--- a/OptiScaler/spoofing/Vulkan_Spoofing.cpp
+++ b/OptiScaler/spoofing/Vulkan_Spoofing.cpp
@@ -37,6 +37,14 @@ static uint32_t vkEnumerateDeviceExtensionPropertiesCount = 0;
 static bool vkEnumerateDeviceExtensionPropertiesListed = false;
 static bool vkEnumerateInstanceExtensionPropertiesListed = false;
 
+static bool SkipVulkanWdx12Hooks()
+{
+    wchar_t value[2] {};
+    const auto length =
+        GetEnvironmentVariableW(L"OPTISCALER_DISABLE_VULKAN_WDX12_HOOKS", value, static_cast<DWORD>(std::size(value)));
+    return length == 1 && value[0] == L'1';
+}
+
 inline static void hkvkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
                                                          VkPhysicalDeviceMemoryProperties* pMemoryProperties)
 {
@@ -752,9 +760,12 @@ PFN_vkVoidFunction VulkanSpoofing::hkvkGetInstanceProcAddr(const PFN_vkVoidFunct
 {
     auto procName = std::string(pName);
 
-    auto result = Vulkan_wDx12::GetInstanceProcAddr(orgFunc, pName);
-    if (result != VK_NULL_HANDLE)
-        return result;
+    if (!SkipVulkanWdx12Hooks())
+    {
+        auto result = Vulkan_wDx12::GetInstanceProcAddr(orgFunc, pName);
+        if (result != VK_NULL_HANDLE)
+            return result;
+    }
 
     if (Config::Instance()->VulkanSpoofing.value_or_default())
     {
@@ -839,9 +850,12 @@ PFN_vkVoidFunction VulkanSpoofing::hkvkGetDeviceProcAddr(const PFN_vkVoidFunctio
 {
     auto procName = std::string(pName);
 
-    auto result = Vulkan_wDx12::GetDeviceProcAddr(orgFunc, pName);
-    if (result != VK_NULL_HANDLE)
-        return result;
+    if (!SkipVulkanWdx12Hooks())
+    {
+        auto result = Vulkan_wDx12::GetDeviceProcAddr(orgFunc, pName);
+        if (result != VK_NULL_HANDLE)
+            return result;
+    }
 
     if (Config::Instance()->VulkanSpoofing.value_or_default())
     {
@@ -924,7 +938,10 @@ PFN_vkVoidFunction VulkanSpoofing::hkvkGetDeviceProcAddr(const PFN_vkVoidFunctio
 
 void VulkanSpoofing::HookForVulkanSpoofing(HMODULE vulkanModule)
 {
-    Vulkan_wDx12::Hook(vulkanModule);
+    if (SkipVulkanWdx12Hooks())
+        LOG_WARN("Skipping Vulkan_wDx12 hooks by diagnostic environment request");
+    else
+        Vulkan_wDx12::Hook(vulkanModule);
 
     if (Config::Instance()->VulkanSpoofing.value_or_default() && o_vkGetPhysicalDeviceProperties == nullptr)
     {


### PR DESCRIPTION

### Problem

OptiScaler installs `Vulkan_wDx12` interception through three independent
entry paths:

1. the direct `Vulkan_wDx12::Hook` detour;
2. `vkGetInstanceProcAddr`;
3. `vkGetDeviceProcAddr`.

On a D3D12 game running through Proton/VKD3D, those hooks can deadlock after a
burst of command-pool creation. Gating only the direct detour is insufficient:
the two dispatch-table paths continue to install the same lower-level hooks.

### Change

Add the off-by-default environment switch
`OPTISCALER_DISABLE_VULKAN_WDX12_HOOKS=1` and apply it consistently to all
three entry paths. Ordinary Vulkan spoofing and presentation behavior remain
unchanged.

The patch is deliberately opt-in. It provides a safe compatibility escape
hatch without changing behavior for existing users or guessing whether a
particular Vulkan device originated from VKD3D.

### Verification

Tested with Clair Obscur: Expedition 33, Steam build 23765773, on:

- Fedora/KDE Wayland, kernel 7.1.12;
- GE-Proton 11-6;
- NVIDIA 610.57.04;
- RTX 5090;
- current VKD3D/DXVK-NVAPI path.

Results:

- no gate: minimal and NR-off controls stall on command-pool/fence waits;
- direct-detour gate only: 84 tracker calls still arrive through the two
  dispatch tables before another stall;
- complete three-path gate: zero tracker command-pool hooks, startup benchmark
  completes, and native DLSS/NR gameplay continues at normal GPU load;
- no new NVIDIA Xid or device-loss event occurs in the successful control.

An independent overlay-only control still stalls and should be handled
separately; this PR does not claim to solve OptiScaler's overlay behavior.
Likewise, a later native-MFG `Auto`-to-`On` recovery experiment is intentionally
excluded: it passed as a diagnostic control, but the accepted 6x configuration
works without it.