### PR TITLE
Fix the ImGui overlay and DLSS-G interlock under vkd3d-proton

### DIFF
--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -134,6 +134,11 @@ class State
     bool dlssgDebugView = false;
     bool dlssgInterpolatedOnly = false;
     uint64_t dlssgLastFrame = 0;
+
+    // Presents MenuOverlayVk must skip before it may submit again. Charged to 10 whenever DLSS-G is
+    // pushed active with the menu hidden, decremented once per present. A game that pushes DLSS-G
+    // options every frame therefore pins it non-zero and the Vulkan overlay draws nothing at all --
+    // FPS overlay and notifications included -- for as long as DLSS-G runs.
     uint32_t delayMenuRenderBy = 0;
 
     // FSR Common
@@ -276,6 +281,9 @@ class State
     bool vulkanCreatingSC = false;
     bool creatingD3DDevice = false;
     bool vulkanSkipHooks = false;
+    // MenuOverlayVk holds ImGui's renderer backend. Independent of swapchainApi, and the condition
+    // MenuOverlayDx::Present stands down on: ImGui has one renderer backend at a time.
+    bool menuOverlayIsVulkan = false;
     VkInstance VulkanInstance = nullptr;
 
     // Framegraph

--- a/OptiScaler/dllmain.cpp
+++ b/OptiScaler/dllmain.cpp
@@ -947,7 +947,16 @@ static void CheckWorkingMode()
 
     // NVAPI
     // Doesn't seem to like GetModuleHandle for some reason, so call our load to make sure
-    if (GetDllNameWModule(&nvapiNamesW) != nullptr)
+    //
+    // Also loaded when it is not present yet and an interface is meant to be withheld. Streamline
+    // resolves its nvapi entry points as it initialises, and a detour installed after that resolve is
+    // never consulted -- the module is hooked, the caller holds addresses from before the hook. Since
+    // Streamline 2.14 that resolve happens first, so DisableFlipMetering stopped taking effect.
+    // Loading it here puts the detour in front of it. Only on Nvidia, and only when something asks,
+    // so no process gains nvapi that would not have had it.
+    if (GetDllNameWModule(&nvapiNamesW) != nullptr ||
+        (Config::Instance()->DisableFlipMetering.value_or_default() &&
+         IdentifyGpu::getPrimaryGpu().vendorId == VendorId::Nvidia))
     {
         // This hooks nvapi as well when possible
         auto nvapi64 = LibraryLoadHooks::LoadNvApi();

--- a/OptiScaler/framegen/dlssg/DLSSG_Dx12.cpp
+++ b/OptiScaler/framegen/dlssg/DLSSG_Dx12.cpp
@@ -8,6 +8,7 @@
 
 #include <hooks/Reflex_Hooks.h>
 #include <hooks/DxgiFactory_Hooks.h>
+#include <hooks/Streamline_Hooks.h>
 
 #include <magic_enum.hpp>
 
@@ -360,6 +361,10 @@ bool DLSSG_Dx12::Dispatch()
         options.mode = sl::DLSSGMode::eDynamic;
         options.dynamicTargetFrameRate = Config::Instance()->FGDLSSGFramerateTargetDMFG.value_or_default();
     }
+
+    // StreamlineProxy holds the raw export, so this push bypasses hkslDLSSGSetOptions and its
+    // interlock. Apply it here too.
+    StreamlineHooks::applyMenuDlssgInterlock(options, true);
 
     auto dlssgSetOptionsResult = StreamlineProxy::DLSSGSetOptions()(viewport, options);
 

--- a/OptiScaler/hooks/Streamline_Hooks.cpp
+++ b/OptiScaler/hooks/Streamline_Hooks.cpp
@@ -1137,19 +1137,7 @@ sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewpo
         newOptions.dynamicTargetFrameRate = Config::Instance()->FGDLSSGFramerateTargetDMFG.value();
     }
 
-    if (state.swapchainApi == API::Vulkan)
-    {
-        // Only matters for Vulkan, DX doesn't use this delay
-        if (dlssgPotentiallyActive && !MenuOverlayBase::IsVisible())
-            state.delayMenuRenderBy = 10;
-
-        if (MenuOverlayBase::IsVisible())
-        {
-            newOptions.mode = sl::DLSSGMode::eOff;
-            newOptions.flags |= sl::DLSSGFlags::eRetainResourcesWhenOff;
-            ReflexHooks::setDlssgFrameCount(0);
-        }
-    }
+    applyMenuDlssgInterlock(newOptions, dlssgPotentiallyActive);
 
     LOG_TRACE("DLSSG Modified Mode: {}", magic_enum::enum_name(newOptions.mode));
 
@@ -1158,6 +1146,7 @@ sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewpo
         // Populate dlssgMfgMax once
         if (!state.dlssgMfgMax.has_value())
         {
+
             sl::DLSSGState localState {};
             sl::DLSSGOptions localOptions {};
             if (o_slDLSSGGetState(viewport, localState, &localOptions) == sl::Result::eOk &&
@@ -1193,6 +1182,7 @@ sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewpo
 sl::Result StreamlineHooks::hkslDLSSGGetState(const sl::ViewportHandle& viewport, sl::DLSSGState& state,
                                               const sl::DLSSGOptions* options)
 {
+
     sl::Result result {};
 
     const auto originalStructVersion = state.structVersion;
@@ -1728,6 +1718,28 @@ void StreamlineHooks::updateDlssgOptions()
         LOG_FUNC();
         hkslDLSSGSetOptions(lastDlssgViewport, lastDlssgOptions);
     }
+}
+
+void StreamlineHooks::applyMenuDlssgInterlock(sl::DLSSGOptions& options, bool dlssgPotentiallyActive)
+{
+    auto& state = State::Instance();
+
+    // Keyed on the overlay, not the swapchain: the submit this guards against is MenuOverlayVk's, and
+    // a title whose swapchainApi is not Vulkan can still have that overlay live.
+    if (state.swapchainApi != API::Vulkan && !state.menuOverlayIsVulkan)
+        return;
+
+    // Charged while the menu is hidden, spent by MenuOverlayVk::QueuePresent once it opens: the
+    // overlay holds off for 10 presents while DLSS-G unwinds. DX overlays do not use this delay.
+    if (dlssgPotentiallyActive && !MenuOverlayBase::IsVisible())
+        state.delayMenuRenderBy = 10;
+
+    if (!MenuOverlayBase::IsVisible())
+        return;
+
+    options.mode = sl::DLSSGMode::eOff;
+    options.flags |= sl::DLSSGFlags::eRetainResourcesWhenOff;
+    ReflexHooks::setDlssgFrameCount(0);
 }
 
 // SL INTERPOSER

--- a/OptiScaler/hooks/Streamline_Hooks.h
+++ b/OptiScaler/hooks/Streamline_Hooks.h
@@ -141,6 +141,11 @@ class StreamlineHooks
     static void updateForceReflex();
     static void updateDlssgOptions();
 
+    // MenuOverlayVk submits on a queue it picks itself, into the present path DLSS-G's pacer owns;
+    // the two cannot run together. Forces options.mode to eOff while the menu is up. Applies to every
+    // DLSS-G option push, including the ones OptiScaler makes through StreamlineProxy.
+    static void applyMenuDlssgInterlock(sl::DLSSGOptions& options, bool dlssgPotentiallyActive);
+
     static void unhookInterposer();
     static void hookInterposer(HMODULE slInterposer);
 

--- a/OptiScaler/hooks/Vulkan_Hooks.cpp
+++ b/OptiScaler/hooks/Vulkan_Hooks.cpp
@@ -252,8 +252,15 @@ static VkResult hkvkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPres
         State::Instance().swapchainApi = Vulkan;
 
     // Tick feature to let it know if it's frozen
-    if (auto currentFeature = State::Instance().currentFeature; currentFeature != nullptr)
-        currentFeature->TickFrozenCheck();
+    //
+    // A vkd3d-proton D3D12 title reaches this and LocalPresent both, and two ticks per present halve
+    // the frozen threshold. Frame generation already spends several presents per evaluate, so the
+    // doubled count crosses it and the feature reads as frozen while the game is running.
+    if (State::Instance().swapchainApi != DX12)
+    {
+        if (auto currentFeature = State::Instance().currentFeature; currentFeature != nullptr)
+            currentFeature->TickFrozenCheck();
+    }
 
     VkPresentInfoKHR localPresentInfo {};
     memcpy(&localPresentInfo, pPresentInfo, sizeof(VkPresentInfoKHR));

--- a/OptiScaler/menu/menu_overlay_dx.cpp
+++ b/OptiScaler/menu/menu_overlay_dx.cpp
@@ -534,6 +534,12 @@ void MenuOverlayDx::Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
         return;
     }
 
+    // MenuOverlayVk holds io.BackendRendererUserData, so ImGui_ImplDX11/DX12 would run against its
+    // data. MenuOverlayVk stands down for vkd3d-proton D3D12 swapchains; this covers the reverse
+    // order, where it claimed the backend first.
+    if (State::Instance().menuOverlayIsVulkan)
+        return;
+
     LOG_DEBUG("");
 
     ID3D12CommandQueue* cq = nullptr;

--- a/OptiScaler/menu/menu_overlay_vk.cpp
+++ b/OptiScaler/menu/menu_overlay_vk.cpp
@@ -9,6 +9,8 @@
 #include <imgui/imgui_impl_vulkan.h>
 #include <imgui/imgui_impl_win32.h>
 
+#include <misc/IdentifyGpu.h>
+
 // Vulkan overlay code adopted from here:
 // https://gist.github.com/mem99/0ec31ca302927457f86b1d6756aaa8c4
 // Need to check resize & recreate fixes
@@ -17,7 +19,6 @@ static bool _isInited = false;
 
 static bool _vulkanObjectsCreated = false;
 static std::mutex _vkCleanMutex;
-static std::mutex _vkPresentMutex;
 
 // imgui stuff
 struct ImGui_ImplVulkan_InitInfo _ImVulkan_Info = {};
@@ -26,6 +27,17 @@ static VkSemaphore* _ImVulkan_Semaphores = VK_NULL_HANDLE;
 static VkRenderPass _vkRenderPass = VK_NULL_HANDLE;
 static uint32_t _scImageCount;
 static ULONG64 _frameCount;
+
+static void DestroyVulkanObjectsLocked(bool shutdown);
+
+// These hooks see vkd3d-proton's presents as well as a native Vulkan game's. swapchainApi is DX12
+// only once a wrapped DXGI swapchain has presented from a D3D12 queue, which under Proton means
+// vkd3d-proton; MenuOverlayDx draws those titles on the game's own queue. Ordering holds: the game's
+// first Present sets swapchainApi before vkd3d creates the VkSwapchain inside it.
+static bool DxOverlayOwnsBackend()
+{
+    return State::Instance().swapchainApi == API::DX12 && IdentifyGpu::getPrimaryGpu().usesDxvk;
+}
 
 static void SetVkObjectName(VkDevice device, VkInstance instance, VkObjectType objectType, uint64_t objectHandle,
                             const char* name)
@@ -45,6 +57,16 @@ static void SetVkObjectName(VkDevice device, VkInstance instance, VkObjectType o
     vkSetDebugUtilsObjectNameEXT(device, &info);
 }
 
+// ImGui_ImplVulkan_InitInfo::CheckVkResultFn. The backend calls it on every result, successes
+// included; filter or the async logger's 8192-slot blocking queue stalls the present thread.
+static void CheckVkResult(VkResult result)
+{
+    if (result == VK_SUCCESS)
+        return;
+
+    LOG_ERROR("ImGui Vulkan backend error: {0:X}", (UINT) result);
+}
+
 static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance instance, HWND hwnd,
                                 const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain)
 {
@@ -58,16 +80,28 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
         return;
     }
 
+    // Teardown of the ImGui backend and of the per-frame handles must appear atomic to QueuePresent.
     if (_vulkanObjectsCreated)
     {
+        std::lock_guard<std::mutex> lock(_vkCleanMutex);
+
         LOG_DEBUG("_vulkanObjectsCreated, releasing objects");
 
         if (ImGui::GetIO().BackendRendererUserData != nullptr)
             ImGui_ImplVulkan_Shutdown(false);
 
-        MenuOverlayVk::DestroyVulkanObjects(false);
+        DestroyVulkanObjectsLocked(false);
 
         _vulkanObjectsCreated = false;
+    }
+
+    // Below the teardown, so a swapchain recreate still releases the objects of the old one. ImGui
+    // holds one renderer backend at a time in io.BackendRendererUserData; leaving it unclaimed is what
+    // lets MenuOverlayDx take it.
+    if (DxOverlayOwnsBackend())
+    {
+        LOG_DEBUG("vkd3d-proton D3D12 swapchain, MenuOverlayDx draws the overlay");
+        return;
     }
 
     // Initialize ImGui
@@ -79,6 +113,11 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
         LOG_DEBUG("MenuOverlayBase::Init");
         MenuOverlayBase::Init(hwnd, false);
     }
+
+    // Starts here, not above: MenuOverlayBase::Init reaches D3D12 device creation, which re-enters the
+    // Vulkan hooks and DestroyVulkanObjects on this thread. Everything below is Vulkan object creation
+    // and the ImGui backend, with no path back into the hooks.
+    std::lock_guard<std::mutex> lock(_vkCleanMutex);
 
     ImGuiIO& io = ImGui::GetIO();
     io.DisplaySize.x = static_cast<float>(pCreateInfo->imageExtent.width);
@@ -367,6 +406,7 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
         _ImVulkan_Info.ImageCount = _scImageCount;
         _ImVulkan_Info.Allocator = NULL;
         _ImVulkan_Info.RenderPass = _vkRenderPass;
+        _ImVulkan_Info.CheckVkResultFn = CheckVkResult;
 
         bool initResult = ImGui_ImplVulkan_Init(&_ImVulkan_Info);
         LOG_DEBUG("ImGui_ImplVulkan_Init result: {}", initResult);
@@ -426,18 +466,21 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
     }
 
     _vulkanObjectsCreated = true;
+    State::Instance().menuOverlayIsVulkan = true;
     LOG_FUNC_RESULT(_vulkanObjectsCreated);
 }
 
-void MenuOverlayVk::DestroyVulkanObjects(bool shutdown)
+// Caller holds _vkCleanMutex.
+static void DestroyVulkanObjectsLocked(bool shutdown)
 {
+    State::Instance().menuOverlayIsVulkan = false;
+
+    // _ImVulkan_Info is zeroed at the tail under this lock; read it here, not before.
     if (_ImVulkan_Info.Device == VK_NULL_HANDLE)
         return;
 
     if (!shutdown)
         LOG_FUNC();
-
-    _vkCleanMutex.lock();
 
     auto result = vkDeviceWaitIdle(_ImVulkan_Info.Device);
     if (result != VK_SUCCESS && !shutdown)
@@ -480,7 +523,7 @@ void MenuOverlayVk::DestroyVulkanObjects(bool shutdown)
             fd->BackbufferView = VK_NULL_HANDLE;
         }
 
-        if (fd->BackbufferView != VK_NULL_HANDLE)
+        if (fd->Framebuffer != VK_NULL_HANDLE)
         {
             vkDestroyFramebuffer(_ImVulkan_Info.Device, fd->Framebuffer, VK_NULL_HANDLE);
             fd->Framebuffer = VK_NULL_HANDLE;
@@ -494,13 +537,22 @@ void MenuOverlayVk::DestroyVulkanObjects(bool shutdown)
     }
 
     _ImVulkan_Info = {};
+}
 
-    _vkCleanMutex.unlock();
+void MenuOverlayVk::DestroyVulkanObjects(bool shutdown)
+{
+    std::lock_guard<std::mutex> lock(_vkCleanMutex);
+    DestroyVulkanObjectsLocked(shutdown);
 }
 
 bool MenuOverlayVk::QueuePresent(VkQueue queue, VkPresentInfoKHR* pPresentInfo)
 {
     LOG_FUNC();
+
+    // Serialises against CreateVulkanObjects/DestroyVulkanObjects: vkDeviceWaitIdle there requires no
+    // concurrent submit on any queue of the device, and the per-frame handles used below are destroyed
+    // under this lock. Dropped across RenderMenu, which re-enters both on this thread.
+    std::unique_lock<std::mutex> lock(_vkCleanMutex);
 
     if (!_vulkanObjectsCreated)
         return true;
@@ -511,7 +563,6 @@ bool MenuOverlayVk::QueuePresent(VkQueue queue, VkPresentInfoKHR* pPresentInfo)
     if (pPresentInfo->swapchainCount == 0)
         return false;
 
-    // std::lock_guard<std::mutex> lock(_vkPresentMutex);
     LOG_DEBUG("rendering menu, swapchain count: {0}", pPresentInfo->swapchainCount);
 
     ImGuiIO& io = ImGui::GetIO();
@@ -521,17 +572,26 @@ bool MenuOverlayVk::QueuePresent(VkQueue queue, VkPresentInfoKHR* pPresentInfo)
     _frameCount++;
 
     {
-        auto semaphoreIndex = _frameCount % _scImageCount;
-
         ImGui_ImplVulkan_NewFrame();
 
         if (State::Instance().delayMenuRenderBy > 0)
             State::Instance().delayMenuRenderBy--;
 
-        if (MenuOverlayBase::RenderMenu())
+        // RenderMenu runs game, Streamline and DXVK code that reaches DestroyVulkanObjects and
+        // CreateVulkanObjects through the Vulkan hooks on this thread. _vkCleanMutex is not recursive.
+        lock.unlock();
+        auto haveFrame = MenuOverlayBase::RenderMenu();
+        lock.lock();
+
+        // Objects can have been torn down and rebuilt while the lock was released.
+        auto objectsUsable = _vulkanObjectsCreated && _ImVulkan_Info.Device != VK_NULL_HANDLE &&
+                             pPresentInfo->pImageIndices[0] < _ImVulkan_Info.ImageCount;
+
+        if (haveFrame)
         {
-            if (State::Instance().delayMenuRenderBy == 0)
+            if (State::Instance().delayMenuRenderBy == 0 && objectsUsable)
             {
+                auto semaphoreIndex = _frameCount % _scImageCount;
                 uint32_t idx = pPresentInfo->pImageIndices[0];
                 ImGui_ImplVulkanH_Frame* fd = &_ImVulkan_Frames[idx];
 
@@ -609,13 +669,21 @@ void MenuOverlayVk::CreateSwapchain(VkDevice device, VkPhysicalDevice pd, VkInst
 {
     LOG_FUNC();
 
-    if (MenuOverlayBase::Handle() != hwnd)
+    // The predicate also guards the shutdown below: where MenuOverlayDx owns ImGui, the renderer
+    // backend behind io.BackendRendererUserData is a DX one and ImGui_ImplVulkan_Shutdown would free
+    // it as if it were Vulkan. CreateVulkanObjects still runs, to release objects of its own.
+    if (MenuOverlayBase::Handle() != hwnd && !DxOverlayOwnsBackend())
     {
         LOG_DEBUG("MenuOverlayBase::Handle() != _hwnd");
 
         if (MenuOverlayBase::IsInited())
         {
-            ImGui_ImplVulkan_Shutdown(false);
+            {
+                // Frees the backend QueuePresent draws through.
+                std::lock_guard<std::mutex> lock(_vkCleanMutex);
+                ImGui_ImplVulkan_Shutdown(false);
+            }
+
             LOG_DEBUG("MenuOverlayBase::Shutdown();");
             MenuOverlayBase::Shutdown();
         }

--- a/OptiScaler/upscalers/IFeature.cpp
+++ b/OptiScaler/upscalers/IFeature.cpp
@@ -278,7 +278,12 @@ void IFeature::TickFrozenCheck()
 
         lastFrameCount = _frameCount;
 
-        _featureFrozen = updatesWithoutFramecountChange > 10;
+        // Ticked once per present, but _frameCount only advances on an evaluate. Frame generation
+        // presents its generated frames between evaluates, so the count reaches the multiplier every
+        // real frame with nothing wrong. Scale the threshold by it.
+        const auto presentsPerEvaluate = std::max(1, State::Instance().dlssgDetectedInterpolationCount + 1);
+
+        _featureFrozen = updatesWithoutFramecountChange > 10L * presentsPerEvaluate;
     }
 }
 

--- a/OptiScaler/wrapped/wrapped_swapchain.cpp
+++ b/OptiScaler/wrapped/wrapped_swapchain.cpp
@@ -324,7 +324,12 @@ static HRESULT LocalPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
     }
 
     // DXVK check, it's here because of upscaler time calculations
-    if (IdentifyGpu::getPrimaryGpu().usesDxvk)
+    //
+    // D3D11 only. vkd3d-proton sets usesDxvk as well, and a D3D12 title returning here leaves
+    // MenuOverlayVk as the only ImGui backend: it submits on a queue of its own into the present path
+    // Streamline owns, which removes the device. Falling through reaches MenuOverlayDx::Present, which
+    // draws on the game's queue.
+    if (IdentifyGpu::getPrimaryGpu().usesDxvk && isD3D11)
     {
         if (pPresentParameters == nullptr)
             presentResult = pSwapChain->Present(SyncInterval, Flags);


### PR DESCRIPTION
Opening the OptiScaler menu on a D3D12 game under Proton removes the GPU device. This fixes that, and four related problems found while tracking it down.

Tested on an RTX 4090 / Cyberpunk 2077 / vkd3d-proton. Builds clean.

## The overlay draws through Vulkan on a D3D12 game

`IdentifyGpu::getPrimaryGpu().usesDxvk` is true for a vkd3d-proton D3D12 title as well as a DXVK D3D11 one, so `LocalPresent` takes the early return at `wrapped_swapchain.cpp:327` and `MenuOverlayDx::Present` is never reached. `MenuOverlayVk` becomes the live ImGui backend.

It then submits on a `VkQueue` it selected itself, unserialised, into the present path Streamline owns. `_vkPresentMutex` is declared twice -- `menu_overlay_vk.cpp:20` and `Vulkan_Hooks.cpp:33` -- and locked nowhere; the `lock_guard` at `:514` is commented out. With DLSS-G active, the first menu open removes the device: `VK_ERROR_DEVICE_LOST` reported by vkd3d's own `hk_vkQueueSubmit2` about half a second after the overlay's submit.

Measured across two runs: menu open with DLSS-G off survived 1257 overlay submits; with DLSS-G on it died after 4. A separate 82-second run with DLSS-G on and the menu never opened had zero device losses.

The early return is now D3D11 only, so these titles reach `MenuOverlayDx::Present` and draw on the game's own queue.

ImGui holds one renderer backend in `io.BackendRendererUserData` and `vkCreateSwapchainKHR` is hooked either way, so both overlays would claim it. `MenuOverlayVk` stands down for a vkd3d-proton D3D12 swapchain, and `MenuOverlayDx::Present` carries the reverse guard in case a different DXVK build creates the VkSwapchain first. Worst case becomes no overlay rather than a wild pointer.

## The DLSS-G interlock never armed

`Streamline_Hooks.cpp` already forces `DLSSGMode::eOff` with `eRetainResourcesWhenOff` while the menu is visible, and charges `delayMenuRenderBy` -- exactly the protection needed here. It is keyed on `state.swapchainApi == API::Vulkan`. Under vkd3d-proton that value is `DX12` while the Vulkan overlay is the live backend, so the guard silently never applied.

It is now keyed on the overlay, via a new `State::menuOverlayIsVulkan` set when `MenuOverlayVk`'s objects are built and cleared on every teardown path. `swapchainApi` is deliberately left alone: it also drives `menu_common.cpp:3197-3275` and `:4643-4690`, and flipping it would grey out DLSS-G and FSR-FG in the menu.

The gate is factored into `StreamlineHooks::applyMenuDlssgInterlock` and called from `DLSSG_Dx12::Dispatch` too, which pushed `eOn` through the raw `StreamlineProxy::DLSSGSetOptions` export and bypassed the hook entirely.

## The frozen check trips under frame generation

`TickFrozenCheck` runs per present; `_frameCount` advances per evaluate. Two problems: these titles reach both `LocalPresent` and `hkvkQueuePresentKHR`, so it ticked twice per present and halved the threshold; and the flat `> 10` assumes one present per evaluate, which frame generation breaks by design. At 4X and above the feature reads as frozen while the game is running, and the menu flashes "is active, but not currently used by the game" every few frames.

One tick per present, and the threshold scales with `dlssgDetectedInterpolationCount`.

## DisableFlipMetering stopped working with Streamline 2.14

`dllmain.cpp` only loads and hooks NVAPI when `nvapi64.dll` is already present, which at init it is not. Streamline 2.14 resolves its NVAPI entry points as it initialises -- before the `QueryInterface` detour is installed -- so the module is hooked but the caller holds pre-hook addresses and the deny list is never consulted.

Confirmed by log ordering: `nvapi64.dll` loads at `12.690`, the hook lands at `12.819`. With the window closed, `FlipMetering is disabled!` fires; without it, never.

NVAPI is now loaded and hooked up front when the option asks for it, guarded on Nvidia and on the option being set, so no process gains NVAPI it would not otherwise have had.

## Three latent defects in menu_overlay_vk

Found while diagnosing the above. None caused the device loss; the second cost real diagnosis time.

- `_ImVulkan_Info.CheckVkResultFn` was never assigned, so ImGui's Vulkan backend discarded every `VkResult` including `DEVICE_LOST` (`imgui_impl_vulkan.cpp:429` is a no-op without it).
- The framebuffer destroy guard tested `fd->BackbufferView` after the preceding block had nulled it, so framebuffers were never destroyed.
- `QueuePresent` and `DestroyVulkanObjects` were unserialised. Now `_vkCleanMutex`, released across `MenuOverlayBase::RenderMenu` and re-validated on re-acquisition -- `RenderMenu` can re-enter `DestroyVulkanObjects` through `IdentifyGpu::getPrimaryGpu()` and the swapchain hook, so a non-recursive mutex held across it would deadlock. The dead duplicate `_vkPresentMutex` declarations are removed.

## Scope

Windows and native-Vulkan behaviour is unchanged: `menuOverlayIsVulkan` is false there and every gate evaluates as before. The routing change affects Proton D3D12 titles, which is the population currently losing the device.

Not runtime-tested on Windows or on a native Vulkan title; I have neither.
