### PR TITLE
MFG on RTX 40 series: unlock the count, and use the kernels that support it

### DIFF
--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -300,6 +300,34 @@ ForceDMFG=auto
 ; Default (auto) is 0.0 (monitor's refresh rate)
 FramerateTargetDMFG=auto
 
+; Multi Frame Generation on RTX 40 series
+;
+; nvngx_dlssg.dll gates the generated frame maximum on the architecture the driver reports and gives
+; anything below Blackwell a maximum of one. This rewrites that decision in memory. The file on disk
+; is not touched; NGX checks its signature and refuses a modified one.
+;
+; Undocumented and unsupported by NVIDIA. A driver update can move the code this looks for, in which
+; case nothing is patched and the log says so.
+; true or false - Default (auto) is false
+AdaMfgUnlock=auto
+
+; Run the Blackwell interpolation kernels on RTX 40 series
+;
+; nvngx_dlssg.dll carries two builds of its kernels. Kernel_EstimateIntermMvecsScatter reads three
+; floats of its parameter block on Blackwell and one on Ada, so on a 40 series card every generated
+; frame is placed at the same point between the two real ones: the 3D image does not advance between
+; them while the interface, composited once per present, does. At 2X there is one frame and nothing to
+; distinguish; above it the world stutters while the HUD glides.
+;
+; The Blackwell build uses no instruction the 40 series lacks, so its image is relabelled to answer
+; for Ada and the ones that answered before are parked on an architecture that does not exist. No code
+; is copied and no payload changes length.
+;
+; The shipped binaries are parked with them, so the driver compiles the kernels on first use: expect
+; one hitch. Requires AdaMfgUnlock.
+; true or false - Default (auto) is true below Blackwell, where the unlock needs it to be worth having
+AdaBlackwellKernels=auto
+
 
 
 ; -------------------------------------------------------

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -242,6 +242,8 @@ bool Config::Reload(std::filesystem::path iniPath)
             FGDLSSGFramerateTargetDMFG.set_from_config(readFloat("DLSSG", "FramerateTargetDMFG"));
             FGDLSSGOverrideForceDMFG.set_from_config(readBool("DLSSG", "OverrideForceDMFG"));
             FGDLSSGForceDMFG.set_from_config(readBool("DLSSG", "ForceDMFG"));
+            FGDLSSGAdaMfgUnlock.set_from_config(readBool("DLSSG", "AdaMfgUnlock"));
+            FGDLSSGAdaBlackwellKernels.set_from_config(readBool("DLSSG", "AdaBlackwellKernels"));
         }
 
         // FSR FG Inputs
@@ -1017,6 +1019,10 @@ bool Config::SaveIni()
         ini.SetValue("DLSSG", "OverrideForceDMFG",
                      GetBoolValue(Instance()->FGDLSSGOverrideForceDMFG.value_for_config()).c_str());
         ini.SetValue("DLSSG", "ForceDMFG", GetBoolValue(Instance()->FGDLSSGForceDMFG.value_for_config()).c_str());
+        ini.SetValue("DLSSG", "AdaMfgUnlock",
+                     GetBoolValue(Instance()->FGDLSSGAdaMfgUnlock.value_for_config()).c_str());
+        ini.SetValue("DLSSG", "AdaBlackwellKernels",
+                     GetBoolValue(Instance()->FGDLSSGAdaBlackwellKernels.value_for_config()).c_str());
     }
 
     // OptiFG

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -606,7 +606,9 @@ class Config
                                            // but someone just uses real DLSSG
     CustomOptional<bool> FGDLSSGOverrideForceDMFG { false };   // Overrides game's DLSSG mode to Dynamic
     CustomOptional<bool> FGDLSSGForceDMFG { false };           // Overrides Opti's DLSSG mode to Dynamic
-    CustomOptional<float> FGDLSSGFramerateTargetDMFG { 0.0f }; // 0.0 means auto-detects the display refresh rate
+    CustomOptional<float> FGDLSSGFramerateTargetDMFG { 0.0f };
+    CustomOptional<bool> FGDLSSGAdaMfgUnlock { false };         // See framegen/dlssg/MfgUnlock.h
+    CustomOptional<bool> FGDLSSGAdaBlackwellKernels { false };  // See framegen/dlssg/MfgUnlock.h // 0.0 means auto-detects the display refresh rate
 
     // As per
     // https://github.com/artur-graniszewski/dlss-enabler-main/blob/a92464d468eb0d91ae17befa66c6bf6229f20b9f/Utils/DlssgProxy.cpp#L1033

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -319,6 +319,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="exports\wininet.h" />
     <ClInclude Include="exports\winmm.h" />
     <ClInclude Include="framegen\dlssg\DLSSG_Dx12.h" />
+    <ClInclude Include="framegen\dlssg\MfgUnlock.h" />
     <ClInclude Include="framegen\ffx\FSRFG_Dx12.h" />
     <ClInclude Include="framegen\IFGFeature.h" />
     <ClInclude Include="framegen\IFGFeature_Dx12.h" />
@@ -605,6 +606,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClCompile Include="gpu_time\GpuTime_Dx12.cpp" />
     <ClCompile Include="hooks\Amdxc64_Hooks.cpp" />
     <ClCompile Include="framegen\dlssg\DLSSG_Dx12.cpp" />
+    <ClCompile Include="framegen\dlssg\MfgUnlock.cpp" />
     <ClCompile Include="framegen\ffx\FSRFG_Dx12.cpp" />
     <ClCompile Include="framegen\IFGFeature.cpp" />
     <ClCompile Include="framegen\IFGFeature_Dx12.cpp" />

--- a/OptiScaler/framegen/dlssg/MfgUnlock.cpp
+++ b/OptiScaler/framegen/dlssg/MfgUnlock.cpp
@@ -1,0 +1,379 @@
+#include "pch.h"
+
+#include "MfgUnlock.h"
+
+#include <Config.h>
+#include <scanner/scanner.h>
+#include <misc/IdentifyGpu.h>
+
+
+namespace
+{
+// mov ebx,1 / mov r8d,3 / cmp edi,0x1b0 / cmovl r8d,ebx. The two counts and the architecture
+// constant together are unique in the module; the wildcards cover nothing, they are here only to
+// keep the shape readable.
+constexpr std::string_view kAdvertisePattern = "BB 01 00 00 00 41 B8 03 00 00 00 81 FF B0 01 00 00 44 0F 4C C3";
+
+// cmp eax,0x1b0 / jl / cmp ebx,3 / jbe. The only comparison against the architecture constant that
+// is followed by a signed branch and a count test.
+constexpr std::string_view kValidatePattern = "3D B0 01 00 00 7C ? 83 FB 03 76";
+
+// sl.dlss_g.dll, where the count nvngx published is taken as min(published, 3):
+//     mov   r8d, 0x3
+//     cmp   ecx, r8d
+//     cmovb r8d, ecx
+// The wrapper carries its own ceiling, so raising nvngx alone gets three back.
+constexpr std::string_view kWrapperClampPattern = "41 B8 03 00 00 00 41 3B C8 44 0F 42 C1";
+
+// Five generated frames, the count both patched sites carry.
+constexpr uint8_t kMaxGeneratedFrames = 5;
+
+// 310.9 restructured both gates. The count is no longer an immediate next to the comparison: the
+// Blackwell branch starts at five and reads a configured value, and anything below Blackwell is sent
+// to a branch that publishes one.
+//     cmp ebp, 0x1b0
+//     jl  ada          <- neutralised, so every card takes the Blackwell branch
+//     mov edi, 0x5
+constexpr std::string_view kAdvertisePattern309 = "81 FD B0 01 00 00 0F 8C ? ? ? ? BF 05 00 00 00";
+
+// The capability flag in the same build is a setae rather than a branch.
+//     cmp   eax, 0x1b0
+//     setae al
+constexpr std::string_view kValidatePattern309 = "3D B0 01 00 00 0F 93 C0";
+
+
+
+// scanner::GetAddress only walks sections marked executable. Fatbins are data, so they need their own
+// search. Returns 0 unless exactly one non-executable section holds the sequence, once.
+uintptr_t FindDataBytes(HMODULE module, const uint8_t* needle, size_t length)
+{
+    auto base = reinterpret_cast<uint8_t*>(module);
+    auto dos = reinterpret_cast<IMAGE_DOS_HEADER*>(base);
+    auto nt = reinterpret_cast<IMAGE_NT_HEADERS64*>(base + dos->e_lfanew);
+    auto section = IMAGE_FIRST_SECTION(nt);
+
+    uintptr_t found = 0;
+    size_t hits = 0;
+
+    for (unsigned i = 0; i < nt->FileHeader.NumberOfSections; ++i)
+    {
+        const auto& s = section[i];
+
+        if (s.Characteristics & IMAGE_SCN_MEM_EXECUTE)
+            continue;
+
+        uint8_t* start = base + s.VirtualAddress;
+        uint8_t* end = start + s.Misc.VirtualSize;
+
+        for (uint8_t* p = std::search(start, end, needle, needle + length); p != end;
+             p = std::search(p + 1, end, needle, needle + length))
+        {
+            found = reinterpret_cast<uintptr_t>(p);
+
+            if (++hits > 1)
+                return 0;
+        }
+    }
+
+    return hits == 1 ? found : 0;
+}
+
+bool WriteBytes(uintptr_t address, const uint8_t* bytes, size_t count)
+{
+    DWORD oldProtect = 0;
+
+    if (!VirtualProtect((LPVOID) address, count, PAGE_EXECUTE_READWRITE, &oldProtect))
+    {
+        LOG_WARN("VirtualProtect failed at {:X}", address);
+        return false;
+    }
+
+    std::memcpy((void*) address, bytes, count);
+
+    DWORD ignored = 0;
+    VirtualProtect((LPVOID) address, count, oldProtect, &ignored);
+    FlushInstructionCache(GetCurrentProcess(), (LPCVOID) address, count);
+
+    return true;
+}
+
+std::string Hex(const uint8_t* bytes, size_t count)
+{
+    std::string out;
+
+    for (size_t i = 0; i < count; ++i)
+        out += std::format("{}{:02X}", i == 0 ? "" : " ", bytes[i]);
+
+    return out;
+}
+
+// Rewrites count and neutralises the architecture clamp, so MultiFrameCountMax is published as five.
+bool PatchAdvertise(HMODULE module)
+{
+    if (const auto at309 = scanner::GetAddress(module, kAdvertisePattern309); at309 != 0)
+    {
+        // The jl is a rel32, six bytes.
+        const auto branchAt = at309 + 6;
+        const uint8_t nop[] = { 0x0F, 0x1F, 0x44, 0x00, 0x00, 0x90 };
+
+        LOG_INFO("MFG unlock: advertise (310.9) at {:X}, jl {} -> {}", at309,
+                 Hex((const uint8_t*) branchAt, sizeof(nop)), Hex(nop, sizeof(nop)));
+
+        return WriteBytes(branchAt, nop, sizeof(nop));
+    }
+
+    const auto address = scanner::GetAddress(module, kAdvertisePattern);
+
+    if (address == 0)
+    {
+        LOG_WARN("MFG unlock: the advertise signature did not match, nvngx_dlssg.dll left alone");
+        return false;
+    }
+
+    // Offsets within the matched sequence: the r8d immediate, and the cmovl.
+    const auto countAt = address + 7;
+    const auto cmovAt = address + 17;
+
+    const uint8_t count[] = { kMaxGeneratedFrames };
+    const uint8_t nop[] = { 0x0F, 0x1F, 0x40, 0x00 };
+
+    LOG_INFO("MFG unlock: advertise at {:X}, count {} -> {}, cmovl {} -> {}", address,
+             *(const uint8_t*) countAt, kMaxGeneratedFrames, Hex((const uint8_t*) cmovAt, sizeof(nop)),
+             Hex(nop, sizeof(nop)));
+
+    return WriteBytes(countAt, count, sizeof(count)) && WriteBytes(cmovAt, nop, sizeof(nop));
+}
+
+// Drops the Ada branch and raises the accepted count, so a request for five is not rejected.
+bool PatchValidate(HMODULE module)
+{
+    if (const auto at309 = scanner::GetAddress(module, kValidatePattern309); at309 != 0)
+    {
+        // setae al -> mov al, 1, so the flag is set whatever the architecture reports.
+        const auto setAt = at309 + 5;
+        const uint8_t always[] = { 0xB0, 0x01, 0x90 };
+
+        LOG_INFO("MFG unlock: validate (310.9) at {:X}, setae {} -> {}", at309,
+                 Hex((const uint8_t*) setAt, sizeof(always)), Hex(always, sizeof(always)));
+
+        return WriteBytes(setAt, always, sizeof(always));
+    }
+
+    const auto address = scanner::GetAddress(module, kValidatePattern);
+
+    if (address == 0)
+    {
+        LOG_WARN("MFG unlock: the validate signature did not match, nvngx_dlssg.dll left alone");
+        return false;
+    }
+
+    // Offsets within the matched sequence: the jl, and the immediate of the count test behind it.
+    const auto branchAt = address + 5;
+    const auto countAt = address + 9;
+
+    const uint8_t nop[] = { 0x90, 0x90 };
+    const uint8_t count[] = { kMaxGeneratedFrames };
+
+    LOG_INFO("MFG unlock: validate at {:X}, jl {} -> {}, count {} -> {}", address,
+             Hex((const uint8_t*) branchAt, sizeof(nop)), Hex(nop, sizeof(nop)), *(const uint8_t*) countAt,
+             kMaxGeneratedFrames);
+
+    return WriteBytes(branchAt, nop, sizeof(nop)) && WriteBytes(countAt, count, sizeof(count));
+}
+
+
+// Gives Ada the Blackwell kernels the module already carries.
+//
+// nvngx_dlssg.dll ships two builds of the interpolation kernels. Kernel_EstimateIntermMvecsScatter
+// reads three f32 fields of its parameter block on sm_120 and one on sm_89, so on Ada every generated
+// frame is placed at the same point between the two real ones: the world does not advance between
+// them while the interface, composited once per present, does. At 2X there is one frame and nothing
+// to distinguish; above it that is the whole symptom.
+//
+// The sm_120 module uses no instruction Ada lacks. So per container: the Blackwell PTX image is
+// relabelled sm_89, its .target directive is rewritten in place (".target sm_120" and
+// ".target sm_89 " are both fourteen bytes, and the directive sits in the literal run at the head of
+// the LZ4 stream), and the images that were sm_89 -- the Ada PTX and its SASS -- are relabelled to an
+// architecture that does not exist so the driver cannot select them. The driver then JITs Blackwell's
+// kernel when it asks for Ada's.
+//
+// Nothing is copied in and no payload changes length. A container without both images is left alone.
+constexpr uint32_t kArchAda = 89;
+constexpr uint32_t kArchBlackwell = 120;
+
+// No such shader model. Parks an image where nothing will ask for it.
+constexpr uint32_t kArchParked = 122;
+
+// Offsets inside a fatbin image header: payload length, and the architecture the image answers for.
+constexpr size_t kImagePayloadSize = 8;
+constexpr size_t kImageArch = 28;
+
+bool PatchBlackwellKernels(HMODULE module)
+{
+    auto base = reinterpret_cast<uint8_t*>(module);
+    auto dos = reinterpret_cast<IMAGE_DOS_HEADER*>(base);
+    auto nt = reinterpret_cast<IMAGE_NT_HEADERS64*>(base + dos->e_lfanew);
+    auto section = IMAGE_FIRST_SECTION(nt);
+
+    const uint8_t magic[] = { 0x50, 0xED, 0x55, 0xBA };
+    unsigned int rewritten = 0;
+
+    for (unsigned i = 0; i < nt->FileHeader.NumberOfSections; ++i)
+    {
+        const auto& s = section[i];
+
+        if (s.Characteristics & IMAGE_SCN_MEM_EXECUTE)
+            continue;
+
+        uint8_t* start = base + s.VirtualAddress;
+        uint8_t* end = start + s.Misc.VirtualSize;
+
+        for (uint8_t* c = std::search(start, end, magic, magic + sizeof(magic)); c < end;
+             c = std::search(c + 1, end, magic, magic + sizeof(magic)))
+        {
+            if (c + 16 > end)
+                break;
+
+            const auto headerSize = *reinterpret_cast<const uint16_t*>(c + 6);
+            const auto fatSize = *reinterpret_cast<const uint64_t*>(c + 8);
+
+            if (headerSize != 0x10 || fatSize == 0 || c + 16 + fatSize > end)
+                continue;
+
+            uint8_t* blackwell = nullptr;
+            size_t blackwellHeader = 0;
+            size_t blackwellPayload = 0;
+            std::vector<uint8_t*> ada;
+
+            for (uint8_t* image = c + 16; image < c + 16 + fatSize;)
+            {
+                const auto kind = *reinterpret_cast<const uint16_t*>(image);
+                const auto imageHeader = *reinterpret_cast<const uint32_t*>(image + 4);
+                const auto payload = *reinterpret_cast<const uint64_t*>(image + kImagePayloadSize);
+                const auto arch = *reinterpret_cast<const uint32_t*>(image + kImageArch);
+
+                if (imageHeader == 0 || payload == 0)
+                    break;
+
+                // kind 1 is PTX, 2 is a cubin. Only the PTX can be retargeted; the cubin is parked.
+                if (kind == 1 && arch == kArchBlackwell)
+                {
+                    blackwell = image;
+                    blackwellHeader = imageHeader;
+                    blackwellPayload = payload;
+                }
+                else if (arch == kArchAda)
+                {
+                    ada.push_back(image);
+                }
+
+                image += imageHeader + payload;
+            }
+
+            if (blackwell == nullptr || ada.empty())
+                continue;
+
+            const char from[] = ".target sm_120";
+            const char to[] = ".target sm_89 ";
+            static_assert(sizeof(from) == sizeof(to), "the directive rewrite must not change length");
+
+            uint8_t* body = blackwell + blackwellHeader;
+            uint8_t* bodyEnd = body + blackwellPayload;
+            auto at = std::search(body, bodyEnd, from, from + sizeof(from) - 1);
+
+            if (at == bodyEnd)
+                continue;
+
+            if (!WriteBytes(reinterpret_cast<uintptr_t>(at), reinterpret_cast<const uint8_t*>(to),
+                            sizeof(to) - 1))
+                continue;
+
+            const uint32_t ada89 = kArchAda;
+            const uint32_t parked = kArchParked;
+
+            WriteBytes(reinterpret_cast<uintptr_t>(blackwell + kImageArch),
+                       reinterpret_cast<const uint8_t*>(&ada89), sizeof(ada89));
+
+            for (uint8_t* image : ada)
+                WriteBytes(reinterpret_cast<uintptr_t>(image + kImageArch),
+                           reinterpret_cast<const uint8_t*>(&parked), sizeof(parked));
+
+            ++rewritten;
+        }
+    }
+
+    LOG_INFO("MFG unlock: {} kernel containers answer Ada with the Blackwell image", rewritten);
+
+    return rewritten > 0;
+}
+
+// Raises the wrapper's own ceiling to match, so the min() keeps what nvngx published.
+bool PatchWrapperClamp(HMODULE module)
+{
+    const auto address = scanner::GetAddress(module, kWrapperClampPattern);
+
+    if (address == 0)
+    {
+        LOG_WARN("MFG unlock: the wrapper clamp signature did not match, sl.dlss_g.dll left alone");
+        return false;
+    }
+
+    // The r8d immediate of the ceiling this clamps against.
+    const auto countAt = address + 2;
+    const uint8_t count[] = { kMaxGeneratedFrames };
+
+    LOG_INFO("MFG unlock: wrapper clamp at {:X}, count {} -> {}", address, *(const uint8_t*) countAt,
+             kMaxGeneratedFrames);
+
+    return WriteBytes(countAt, count, sizeof(count));
+}
+} // namespace
+
+void MfgUnlock::TryApply()
+{
+    if (!Config::Instance()->FGDLSSGAdaMfgUnlock.value_or_default())
+        return;
+
+    // The two modules arrive at different times and each is latched on its own, so whichever is
+    // present first is patched then rather than waiting for the other.
+    static bool snippetDone = false;
+    static bool wrapperDone = false;
+
+    if (!snippetDone)
+    {
+        if (auto module = GetModuleHandleW(L"nvngx_dlssg.dll"); module != nullptr)
+        {
+            snippetDone = true;
+
+            const bool advertise = PatchAdvertise(module);
+            const bool validate = PatchValidate(module);
+
+            // Default on where it applies: below Blackwell the unlock alone produces frames that do
+            // not advance the picture, so the two belong together. dlssCapable is set from the same
+            // field, so an architecture that never reported leaves this off.
+            const auto& gpu = IdentifyGpu::getPrimaryGpu();
+            const bool preBlackwell = gpu.vendorId == VendorId::Nvidia &&
+                                      gpu.nvidiaArchInfo.architecture_id >= NV_GPU_ARCHITECTURE_TU100 &&
+                                      gpu.nvidiaArchInfo.architecture_id <= NV_GPU_ARCHITECTURE_AD100;
+
+            if (Config::Instance()->FGDLSSGAdaBlackwellKernels.value_or(preBlackwell))
+                PatchBlackwellKernels(module);
+
+            if (advertise && validate)
+                LOG_INFO("MFG unlock: nvngx_dlssg.dll patched for {} generated frames", kMaxGeneratedFrames);
+            else
+                LOG_WARN("MFG unlock: nvngx_dlssg.dll incomplete, advertise {}, validate {}", advertise, validate);
+        }
+    }
+
+    if (!wrapperDone)
+    {
+        if (auto module = GetModuleHandleW(L"sl.dlss_g.dll"); module != nullptr)
+        {
+            wrapperDone = true;
+
+            if (PatchWrapperClamp(module))
+                LOG_INFO("MFG unlock: sl.dlss_g.dll ceiling raised to {}", kMaxGeneratedFrames);
+        }
+    }
+}

--- a/OptiScaler/framegen/dlssg/MfgUnlock.h
+++ b/OptiScaler/framegen/dlssg/MfgUnlock.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Multi Frame Generation on Ada.
+//
+// nvngx_dlssg.dll gates MFG on the architecture id reported by the driver: 0x1b0 is Blackwell, Ada
+// is below it. Two sites decide what a card is allowed to do, and both compare against that constant.
+//
+//   Advertise, the function that publishes DLSSG.MultiFrameCountMax:
+//       mov   ebx, 0x1
+//       mov   r8d, 0x3            the Blackwell count
+//       cmp   edi, 0x1b0
+//       cmovl r8d, ebx            below Blackwell the count becomes 1
+//
+//   Validate, the function that accepts or rejects a requested count:
+//       cmp   eax, 0x1b0
+//       jl    ada                 Ada takes this branch and accepts only 1
+//       cmp   ebx, 0x3
+//       jbe   accept
+//
+// Patched: the count immediates become 5, the cmovl becomes a nop, and the jl becomes two nops. The
+// result is a maximum of five generated frames -- 6X -- on any architecture.
+//
+// Memory only. The file on disk carries an Authenticode signature and is left alone.
+//
+// Not covered: nvngx_dlssg.dll's frame pacing assumes Blackwell's flip metering hardware, which Ada
+// does not have, so spacing above 2X is uneven. The published mods correct it by rewriting a blend
+// weight inside the model's PTX; that is not done here.
+namespace MfgUnlock
+{
+// Applies both patches once per process. Silent and harmless when the config option is off, when
+// nvngx_dlssg.dll is not loaded, or when either signature does not match exactly once.
+void TryApply();
+} // namespace MfgUnlock

--- a/OptiScaler/hooks/LibraryLoad_Hooks.cpp
+++ b/OptiScaler/hooks/LibraryLoad_Hooks.cpp
@@ -4,6 +4,8 @@
 #include <Config.h>
 #include <DllNames.h>
 
+#include <framegen/dlssg/MfgUnlock.h>
+
 #include <proxies/Ntdll_Proxy.h>
 #include <proxies/Kernel32_Proxy.h>
 #include <proxies/Dxgi_Proxy.h>
@@ -105,6 +107,23 @@ HMODULE LibraryLoadHooks::LoadLibraryCheckW(std::wstring libName, LPCWSTR lpLibF
             return nvngxDlss;
         else
             LOG_ERROR("Trying to load dll: {}", libNameA);
+    }
+
+    // nvngx_dlssg
+    //
+    // The module publishes DLSSG.MultiFrameCountMax while it initialises and slDLSSGGetState returns
+    // the published value rather than recomputing it, so the patch has to be in before anything in
+    // here runs. Patching at the first GetState is one call too late.
+    if (libName.contains(L"nvngx_dlssg"))
+    {
+        auto dlssgSnippet = NtdllProxy::LoadLibraryExW_Ldr(lpLibFullPath, NULL, 0);
+
+        if (dlssgSnippet != nullptr)
+            MfgUnlock::TryApply();
+        else
+            LOG_ERROR("Trying to load dll as nvngx_dlssg: {}", libNameA);
+
+        return dlssgSnippet;
     }
 
     // NGX OTA

--- a/OptiScaler/hooks/Streamline_Hooks.cpp
+++ b/OptiScaler/hooks/Streamline_Hooks.cpp
@@ -8,6 +8,7 @@
 #include <nvapi/fakenvapi.h>
 #include <misc/IdentifyGpu.h>
 #include <hooks/Reflex_Hooks.h>
+#include <framegen/dlssg/MfgUnlock.h>
 #include <menu/menu_overlay_base.h>
 #include <framegen/nvngx/Nvngx_FG.h>
 #include <proxies/KernelBase_Proxy.h>
@@ -1158,6 +1159,9 @@ sl::Result StreamlineHooks::hkslDLSSGSetOptions(const sl::ViewportHandle& viewpo
         // Populate dlssgMfgMax once
         if (!state.dlssgMfgMax.has_value())
         {
+            // Before the read, so the count this captures is the patched one.
+            MfgUnlock::TryApply();
+
             sl::DLSSGState localState {};
             sl::DLSSGOptions localOptions {};
             if (o_slDLSSGGetState(viewport, localState, &localOptions) == sl::Result::eOk &&


### PR DESCRIPTION
Multi frame generation above 2X on RTX 40 series.

`nvngx_dlssg.dll` gates the generated frame maximum on the architecture the driver reports, and ships **two builds of its interpolation kernels**. Opening the gate alone is not enough, which is why unlocking the count by itself produces a higher frame counter and no more motion.

Tested on an RTX 4090 under Proton with Cyberpunk 2077, DLSS-G 310.9 and 310.1.

## Why the count alone is not enough

`Kernel_EstimateIntermMvecsScatter` reads three `f32` fields of its parameter block on `sm_120` and one on `sm_89`:

```
sm_120: ld.param.f32 ... [param_0+32] [param_0+120] [param_0+128]
sm_89:  ld.param.f32 ...                            [param_0+128]
```

That kernel estimates the intermediate motion vectors that place each generated frame at its own point in time. Ada's build ignores the two fields that distinguish one from the next, so every generated frame lands at the same instant. At 2X there is one frame and nothing to distinguish, which is why 2X has always looked correct. Above it the 3D image does not advance between frames while the interface, composited once per present, does — the counter rises and the motion does not.

## The gate

```
cmp ebp, 0x1b0        the Blackwell architecture id
jl  ada               below it the published maximum becomes one
mov edi, 0x5          Blackwell starts at five
```

The branch is neutralised so every card gets the count Blackwell gets. A second site sets the capability flag with `setae` against the same constant and becomes an unconditional set. 310.1 shapes both differently — an immediate beside the compare rather than a data-driven count — and is matched separately.

## The kernels

The `sm_120` module uses no instruction Ada lacks; retargeted to `sm_89` it compiles clean under `ptxas`. So per fatbin container:

- the `sm_120` PTX image is relabelled `sm_89`
- its `.target` directive is rewritten in place — `".target sm_120"` and `".target sm_89 "` are both fourteen bytes, and the directive sits in the literal run at the head of the LZ4 stream
- the images that answered for `sm_89`, the Ada PTX and its cubin, are relabelled to an architecture that does not exist

The driver then JITs Blackwell's kernel when it asks for Ada's. **No code is copied into this binary** and no payload changes length — it is three `u32` writes and one fourteen-byte edit per container. Verified with `cuobjdump`: the rewritten container reports `['sm_89', 'sm_122', 'sm_122']` with the `sm_89` slot reading all three parameter fields.

Because the shipped cubins are parked with the Ada PTX, the driver compiles these on first use. Expect one hitch.

## Safety

Both patches are signature matched and act only on what they recognise. A driver update that moves the code leaves the module exactly as it shipped and says so in the log. Nothing is written to disk — NGX validates the Authenticode signature on these modules and refuses a modified file outright, so on-disk patching disables DLSS-G entirely.

## Defaults

`AdaMfgUnlock` is off. It defeats a vendor gate, and opting into that should be deliberate.

`AdaBlackwellKernels` defaults on below Blackwell, gated behind `AdaMfgUnlock`: without it the unlock produces frames that do not advance the picture, so the two only make sense together.

## Measured

6X requested and delivered: `numFramesToGenerate=5`, 31 containers retargeted, presents 31% under 2 ms and 43% between 2 and 6 ms, 5% over 14 ms. Before the kernel swap the same configuration produced a higher counter and visibly worse motion than 2X.

Not tested on Windows or on Blackwell hardware; I have neither. On Blackwell the architecture test fails and both patches are no-ops.
